### PR TITLE
feat(search): add --web flag to open results in browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Added
+
+- `kagi search --web` to open search results in the default web browser instead of outputting to terminal
+
 ## [0.4.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +709,7 @@ dependencies = [
  "cliclack",
  "console",
  "ctrlc",
+ "open",
  "reqwest",
  "scraper",
  "serde",
@@ -697,6 +717,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "urlencoding",
 ]
 
 [[package]]
@@ -806,6 +827,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +859,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -1638,6 +1676,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ clap_complete = "4.6.0"
 cliclack = "0.5.2"
 console = "0.16.3"
 ctrlc = "3.5.2"
+open = "5"
 reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls"] }
 scraper = "0.26.0"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -35,3 +36,4 @@ serde_json = "1.0.149"
 thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }
 toml = "1.1.1"
+urlencoding = "2"

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ prefix a search with one of your configured snaps:
 kagi search --snap reddit "rust async runtime"
 ```
 
+open search results in your default web browser:
+
+```bash
+kagi search --web "rust release notes"
+```
+
 run a filtered search against the subscriber web-product path:
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,12 +231,16 @@ pub struct SearchArgs {
     #[arg(value_name = "QUERY", required = true)]
     pub query: String,
 
+    /// Open search results in the default web browser instead of outputting to terminal
+    #[arg(long)]
+    pub web: bool,
+
     /// Output format
-    #[arg(long, value_name = "FORMAT", default_value_t = OutputFormat::Json)]
+    #[arg(long, value_name = "FORMAT", default_value_t = OutputFormat::Json, conflicts_with = "web")]
     pub format: OutputFormat,
 
     /// Disable colored terminal output (only affects pretty format)
-    #[arg(long)]
+    #[arg(long, conflicts_with = "web")]
     pub no_color: bool,
 
     /// Prefix the search with a Snap shortcut (for example "reddit" becomes "@reddit QUERY")
@@ -1320,5 +1324,49 @@ mod tests {
 
         let rendered = error.to_string();
         assert!(rendered.contains("--shortcut-menu"));
+    }
+
+    #[test]
+    fn parses_search_web_flag() {
+        let cli = Cli::try_parse_from(["kagi", "search", "--web", "rust"])
+            .expect("search --web should parse");
+
+        match cli.command.expect("command") {
+            Commands::Search(args) => {
+                assert!(args.web);
+                assert_eq!(args.query, "rust");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_search_without_web_flag() {
+        let cli = Cli::try_parse_from(["kagi", "search", "rust"]).expect("search should parse");
+
+        match cli.command.expect("command") {
+            Commands::Search(args) => {
+                assert!(!args.web);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_search_web_with_format() {
+        let error = Cli::try_parse_from(["kagi", "search", "--web", "--format", "pretty", "rust"])
+            .expect_err("--web and --format should conflict");
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("--web"));
+    }
+
+    #[test]
+    fn rejects_search_web_with_no_color() {
+        let error = Cli::try_parse_from(["kagi", "search", "--web", "--no-color", "rust"])
+            .expect_err("--web and --no-color should conflict");
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("--web"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,15 +116,20 @@ async fn run() -> Result<(), KagiError> {
                 personalized: args.personalized,
                 no_personalized: args.no_personalized,
             };
-            let request = build_search_request(args.query, &options);
-            let format_str = match args.format {
-                cli::OutputFormat::Json => "json",
-                cli::OutputFormat::Pretty => "pretty",
-                cli::OutputFormat::Compact => "compact",
-                cli::OutputFormat::Markdown => "markdown",
-                cli::OutputFormat::Csv => "csv",
-            };
-            run_search(request, format_str.to_string(), !args.no_color).await
+            if args.web {
+                let request = build_search_request(args.query, &options);
+                open_search_in_browser(&request)
+            } else {
+                let request = build_search_request(args.query, &options);
+                let format_str = match args.format {
+                    cli::OutputFormat::Json => "json",
+                    cli::OutputFormat::Pretty => "pretty",
+                    cli::OutputFormat::Compact => "compact",
+                    cli::OutputFormat::Markdown => "markdown",
+                    cli::OutputFormat::Csv => "csv",
+                };
+                run_search(request, format_str.to_string(), !args.no_color).await
+            }
         }
         Commands::Auth(auth) => match auth.command {
             AuthSubcommand::Status => run_auth_status(),
@@ -871,6 +876,48 @@ fn build_search_request(query: String, options: &SearchRequestOptions) -> search
     request
 }
 
+fn build_kagi_search_url(request: &search::SearchRequest) -> String {
+    let mut url = format!(
+        "https://kagi.com/search?q={}",
+        urlencoding::encode(request.query.trim())
+    );
+    if let Some(lens) = request.lens.as_deref() {
+        url.push_str(&format!("&l={}", urlencoding::encode(lens)));
+    }
+    if let Some(region) = request.region.as_deref() {
+        url.push_str(&format!("&r={}", urlencoding::encode(region)));
+    }
+    if let Some(time_filter) = request.time_filter.as_deref() {
+        url.push_str(&format!("&dr={}", urlencoding::encode(time_filter)));
+    }
+    if let Some(from_date) = request.from_date.as_deref() {
+        url.push_str(&format!("&from_date={}", urlencoding::encode(from_date)));
+    }
+    if let Some(to_date) = request.to_date.as_deref() {
+        url.push_str(&format!("&to_date={}", urlencoding::encode(to_date)));
+    }
+    if let Some(order) = request.order.as_deref() {
+        url.push_str(&format!("&order={}", urlencoding::encode(order)));
+    }
+    if request.verbatim == Some(true) {
+        url.push_str("&verbatim=1");
+    }
+    if let Some(personalized) = request.personalized {
+        url.push_str(if personalized {
+            "&personalized=1"
+        } else {
+            "&personalized=0"
+        });
+    }
+    url
+}
+
+fn open_search_in_browser(request: &search::SearchRequest) -> Result<(), KagiError> {
+    request.validate()?;
+    let url = build_kagi_search_url(request);
+    open::that(&url).map_err(|error| KagiError::Config(format!("failed to open browser: {error}")))
+}
+
 fn search_auth_requirement(request: &search::SearchRequest) -> SearchAuthRequirement {
     if request.lens.is_some() {
         SearchAuthRequirement::Lens
@@ -1228,13 +1275,14 @@ async fn run_batch_search(
 #[cfg(test)]
 mod tests {
     use super::{
-        RateLimiter, SearchRequestOptions, bool_flag_choice, build_search_request,
-        format_csv_response, format_markdown_response, format_pretty_response,
-        is_bare_auth_invocation_from, parse_context_memory_json, print_assistant_response,
-        should_fallback_to_session,
+        RateLimiter, SearchRequestOptions, bool_flag_choice, build_kagi_search_url,
+        build_search_request, format_csv_response, format_markdown_response,
+        format_pretty_response, is_bare_auth_invocation_from, parse_context_memory_json,
+        print_assistant_response, should_fallback_to_session,
     };
     use crate::cli::{AssistantOutputFormat, SearchOrder, SearchTime};
     use crate::error::KagiError;
+    use crate::search;
     use crate::types::{
         AssistantMessage, AssistantMeta, AssistantPromptResponse, AssistantThread, SearchResponse,
         SearchResult,
@@ -1372,6 +1420,51 @@ mod tests {
         );
 
         assert_eq!(request.query, "@reddit rust");
+    }
+
+    #[test]
+    fn builds_kagi_search_url_for_plain_query() {
+        let request = search::SearchRequest::new("rust programming");
+        let url = build_kagi_search_url(&request);
+        assert_eq!(url, "https://kagi.com/search?q=rust%20programming");
+    }
+
+    #[test]
+    fn builds_kagi_search_url_with_all_filters() {
+        let request = search::SearchRequest::new("rust")
+            .with_lens("2")
+            .with_region("us")
+            .with_time_filter("3")
+            .with_order("4")
+            .with_verbatim(true)
+            .with_personalized(false);
+
+        let url = build_kagi_search_url(&request);
+        assert!(url.starts_with("https://kagi.com/search?q=rust"));
+        assert!(url.contains("&l=2"));
+        assert!(url.contains("&r=us"));
+        assert!(url.contains("&dr=3"));
+        assert!(url.contains("&order=4"));
+        assert!(url.contains("&verbatim=1"));
+        assert!(url.contains("&personalized=0"));
+    }
+
+    #[test]
+    fn builds_kagi_search_url_with_date_range() {
+        let request = search::SearchRequest::new("rust")
+            .with_from_date("2026-01-01")
+            .with_to_date("2026-03-01");
+
+        let url = build_kagi_search_url(&request);
+        assert!(url.contains("&from_date=2026-01-01"));
+        assert!(url.contains("&to_date=2026-03-01"));
+    }
+
+    #[test]
+    fn builds_kagi_search_url_encodes_special_characters() {
+        let request = search::SearchRequest::new("what is rust?");
+        let url = build_kagi_search_url(&request);
+        assert_eq!(url, "https://kagi.com/search?q=what%20is%20rust%3F");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `--web` flag to `kagi search` that opens results in the default web browser instead of outputting to terminal
- All existing search filters (lens, region, time, date range, order, verbatim, personalized) are forwarded as URL query params
- Uses the `open` crate for cross-platform browser launching and `urlencoding` for URL encoding

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] New tests for CLI flag parsing (`parses_search_web_flag`, `parses_search_without_web_flag`)
- [x] New tests for URL construction (`builds_kagi_search_url_for_plain_query`, `builds_kagi_search_url_with_all_filters`, `builds_kagi_search_url_with_date_range`, `builds_kagi_search_url_encodes_special_characters`)
- [ ] Manual: `kagi search --web "rust programming"` opens `https://kagi.com/search?q=rust%20programming` in default browser
- [x] Manual: `kagi search --web --lens 2 "docs"` opens browser with lens param