### PR TITLE
[nightshift] ci-fixes: add concurrency groups to 4 workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: npm-publish-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** CI/CD Fixes
**Category:** PR
**Changes:** Add concurrency groups to coverage, npm-publish, release, and security workflows to prevent duplicate runs on the same ref. Release uses cancel-in-progress: false to avoid killing in-progress releases.

Already up-to-date: actions/checkout@v6.0.2, upload-artifact@v7.0.0, download-artifact@v8.0.1, setup-node@v6.3.0, dependabot configured.

Merge if useful, close if not.