### PR TITLE
test(cli): add mocked golden-path integration coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f"
+dependencies = [
+ "async-lock",
+ "event-listener",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +120,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block2"
@@ -99,6 +150,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -192,6 +246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +264,31 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -256,6 +344,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -315,6 +413,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +454,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -351,10 +486,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -363,9 +521,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -405,10 +574,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -466,6 +678,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-trait",
+ "base64",
+ "bytes",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-timer",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "path-tree",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "stringmetrics",
+ "tabwriter",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,9 +727,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -699,10 +953,12 @@ dependencies = [
  "cliclack",
  "console",
  "ctrlc",
+ "httpmock",
  "reqwest",
  "scraper",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",
@@ -721,6 +977,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -774,6 +1036,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -841,6 +1109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +1135,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "path-tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -1076,6 +1359,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1452,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1296,6 +1604,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1644,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1668,22 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
@@ -1405,6 +1750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringmetrics"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1796,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1532,6 +1905,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1555,6 +1929,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1648,6 +2035,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1708,6 +2096,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
@@ -1774,6 +2168,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,7 @@ tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }
 toml = "1.1.1"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+
+[dev-dependencies]
+httpmock = "0.8.3"
+tempfile = "3.27.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -44,47 +44,43 @@ use crate::types::{
     TranslateWarning, TranslationSuggestionsResponse, WordInsightsResponse,
 };
 
-const KAGI_SUMMARIZE_URL: &str = "https://kagi.com/api/v0/summarize";
-const KAGI_SUBSCRIBER_SUMMARIZE_URL: &str = "https://kagi.com/mother/summary_labs";
-const KAGI_NEWS_LATEST_URL: &str = "https://news.kagi.com/api/batches/latest";
-const KAGI_NEWS_CATEGORIES_METADATA_URL: &str = "https://news.kagi.com/api/categories/metadata";
-const KAGI_NEWS_BATCH_CATEGORIES_URL: &str = "https://news.kagi.com/api/batches";
+const KAGI_SUMMARIZE_PATH: &str = "/api/v0/summarize";
+const KAGI_SUBSCRIBER_SUMMARIZE_PATH: &str = "/mother/summary_labs";
+const KAGI_NEWS_LATEST_PATH: &str = "/api/batches/latest";
+const KAGI_NEWS_CATEGORIES_METADATA_PATH: &str = "/api/categories/metadata";
+const KAGI_NEWS_BATCH_CATEGORIES_PATH: &str = "/api/batches";
 const NEWS_FILTER_PRESETS_JSON: &str = include_str!("../data/news-filter-presets.json");
-const KAGI_ASSISTANT_PROMPT_URL: &str = "https://kagi.com/assistant/prompt";
-const KAGI_ASSISTANT_THREAD_OPEN_URL: &str = "https://kagi.com/assistant/thread_open";
-const KAGI_ASSISTANT_THREAD_LIST_URL: &str = "https://kagi.com/assistant/thread_list";
-const KAGI_ASSISTANT_THREAD_DELETE_URL: &str = "https://kagi.com/assistant/thread_delete";
-const KAGI_SETTINGS_ASSISTANT_URL: &str = "https://kagi.com/html/settings/assistant";
-const KAGI_SETTINGS_CUSTOM_ASSISTANT_URL: &str = "https://kagi.com/settings/custom_assistant";
-const KAGI_SETTINGS_CUSTOM_ASSISTANT_UPDATE_URL: &str =
-    "https://kagi.com/settings/ast/profiles/update";
-const KAGI_SETTINGS_CUSTOM_ASSISTANT_DELETE_URL: &str =
-    "https://kagi.com/settings/ast/profiles/delete";
-const KAGI_SETTINGS_LENSES_URL: &str = "https://kagi.com/html/settings/lenses";
-const KAGI_SETTINGS_CREATE_LENS_URL: &str = "https://kagi.com/settings/create_lens";
-const KAGI_LENSES_CREATE_URL: &str = "https://kagi.com/lenses/create";
-const KAGI_LENSES_UPDATE_URL: &str = "https://kagi.com/lenses/update";
-const KAGI_LENSES_DELETE_URL: &str = "https://kagi.com/lenses/delete";
-const KAGI_LENSES_SUBSCRIBE_URL: &str = "https://kagi.com/lenses/subscribe";
-const KAGI_SETTINGS_CUSTOM_BANGS_URL: &str = "https://kagi.com/settings/custom_bangs";
-const KAGI_SETTINGS_CUSTOM_BANG_FORM_URL: &str = "https://kagi.com/settings/custom_bangs_form";
-const KAGI_CUSTOM_BANGS_MODIFY_URL: &str = "https://kagi.com/bangs/modify";
-const KAGI_SETTINGS_REDIRECTS_URL: &str = "https://kagi.com/settings/redirects";
-const KAGI_REDIRECTS_CREATE_UPDATE_URL: &str = "https://kagi.com/rewrite_rules";
-const KAGI_REDIRECTS_DELETE_URL: &str = "https://kagi.com/rewrite_rules/delete";
-const KAGI_REDIRECTS_TOGGLE_URL: &str = "https://kagi.com/rewrite_rules/toggle";
-const KAGI_FASTGPT_URL: &str = "https://kagi.com/api/v0/fastgpt";
-const KAGI_ENRICH_WEB_URL: &str = "https://kagi.com/api/v0/enrich/web";
-const KAGI_ENRICH_NEWS_URL: &str = "https://kagi.com/api/v0/enrich/news";
-const KAGI_SMALLWEB_FEED_URL: &str = "https://kagi.com/api/v1/smallweb/feed/";
-const KAGI_TRANSLATE_DETECT_URL: &str = "https://translate.kagi.com/api/detect";
-const KAGI_TRANSLATE_URL: &str = "https://translate.kagi.com/api/translate";
-const KAGI_TRANSLATE_ALTERNATIVES_URL: &str =
-    "https://translate.kagi.com/api/alternative-translations";
-const KAGI_TRANSLATE_ALIGNMENTS_URL: &str = "https://translate.kagi.com/api/text-alignments";
-const KAGI_TRANSLATE_SUGGESTIONS_URL: &str =
-    "https://translate.kagi.com/api/translation-suggestions";
-const KAGI_TRANSLATE_WORD_INSIGHTS_URL: &str = "https://translate.kagi.com/api/word-insights";
+const KAGI_ASSISTANT_PROMPT_PATH: &str = "/assistant/prompt";
+const KAGI_ASSISTANT_THREAD_OPEN_PATH: &str = "/assistant/thread_open";
+const KAGI_ASSISTANT_THREAD_LIST_PATH: &str = "/assistant/thread_list";
+const KAGI_ASSISTANT_THREAD_DELETE_PATH: &str = "/assistant/thread_delete";
+const KAGI_SETTINGS_ASSISTANT_PATH: &str = "/html/settings/assistant";
+const KAGI_SETTINGS_CUSTOM_ASSISTANT_PATH: &str = "/settings/custom_assistant";
+const KAGI_SETTINGS_CUSTOM_ASSISTANT_UPDATE_PATH: &str = "/settings/ast/profiles/update";
+const KAGI_SETTINGS_CUSTOM_ASSISTANT_DELETE_PATH: &str = "/settings/ast/profiles/delete";
+const KAGI_SETTINGS_LENSES_PATH: &str = "/html/settings/lenses";
+const KAGI_SETTINGS_CREATE_LENS_PATH: &str = "/settings/create_lens";
+const KAGI_LENSES_CREATE_PATH: &str = "/lenses/create";
+const KAGI_LENSES_UPDATE_PATH: &str = "/lenses/update";
+const KAGI_LENSES_DELETE_PATH: &str = "/lenses/delete";
+const KAGI_LENSES_SUBSCRIBE_PATH: &str = "/lenses/subscribe";
+const KAGI_SETTINGS_CUSTOM_BANGS_PATH: &str = "/settings/custom_bangs";
+const KAGI_SETTINGS_CUSTOM_BANG_FORM_PATH: &str = "/settings/custom_bangs_form";
+const KAGI_CUSTOM_BANGS_MODIFY_PATH: &str = "/bangs/modify";
+const KAGI_SETTINGS_REDIRECTS_PATH: &str = "/settings/redirects";
+const KAGI_REDIRECTS_CREATE_UPDATE_PATH: &str = "/rewrite_rules";
+const KAGI_REDIRECTS_DELETE_PATH: &str = "/rewrite_rules/delete";
+const KAGI_REDIRECTS_TOGGLE_PATH: &str = "/rewrite_rules/toggle";
+const KAGI_FASTGPT_PATH: &str = "/api/v0/fastgpt";
+const KAGI_ENRICH_WEB_PATH: &str = "/api/v0/enrich/web";
+const KAGI_ENRICH_NEWS_PATH: &str = "/api/v0/enrich/news";
+const KAGI_SMALLWEB_FEED_PATH: &str = "/api/v1/smallweb/feed/";
+const KAGI_TRANSLATE_DETECT_PATH: &str = "/api/detect";
+const KAGI_TRANSLATE_PATH: &str = "/api/translate";
+const KAGI_TRANSLATE_ALTERNATIVES_PATH: &str = "/api/alternative-translations";
+const KAGI_TRANSLATE_ALIGNMENTS_PATH: &str = "/api/text-alignments";
+const KAGI_TRANSLATE_SUGGESTIONS_PATH: &str = "/api/translation-suggestions";
+const KAGI_TRANSLATE_WORD_INSIGHTS_PATH: &str = "/api/word-insights";
 const ASSISTANT_ZERO_BRANCH_UUID: &str = "00000000-0000-4000-0000-000000000000";
 const TRANSLATE_BOOTSTRAP_MAX_ATTEMPTS: usize = 3;
 const TRANSLATE_BOOTSTRAP_MISSING_COOKIE_ERROR: &str =
@@ -121,7 +117,7 @@ pub async fn execute_summarize(
 
     let client = build_client()?;
     let response = client
-        .post(KAGI_SUMMARIZE_URL)
+        .post(http::kagi_url(KAGI_SUMMARIZE_PATH))
         .header(header::AUTHORIZATION, format!("Bot {token}"))
         .header(header::CONTENT_TYPE, "application/json")
         .json(request)
@@ -153,7 +149,7 @@ pub async fn execute_subscriber_summarize(
 
     let client = build_client()?;
     let response = client
-        .get(KAGI_SUBSCRIBER_SUMMARIZE_URL)
+        .get(http::kagi_url(KAGI_SUBSCRIBER_SUMMARIZE_PATH))
         .query(&[
             (field_name, source_value.as_str()),
             ("stream", "1"),
@@ -212,7 +208,7 @@ pub async fn execute_news(
     let normalized_lang = normalize_news_lang(lang);
     let latest_batch: NewsLatestBatch = decode_kagi_free_json(
         client
-            .get(KAGI_NEWS_LATEST_URL)
+            .get(http::kagi_news_url(KAGI_NEWS_LATEST_PATH))
             .query(&[("lang", normalized_lang.as_str())])
             .send()
             .await
@@ -222,7 +218,7 @@ pub async fn execute_news(
     .await?;
     let metadata: NewsCategoryMetadataList = decode_kagi_free_json(
         client
-            .get(KAGI_NEWS_CATEGORIES_METADATA_URL)
+            .get(http::kagi_news_url(KAGI_NEWS_CATEGORIES_METADATA_PATH))
             .send()
             .await
             .map_err(map_transport_error)?,
@@ -233,7 +229,8 @@ pub async fn execute_news(
         client
             .get(format!(
                 "{}/{}/categories",
-                KAGI_NEWS_BATCH_CATEGORIES_URL, latest_batch.id
+                http::kagi_news_url(KAGI_NEWS_BATCH_CATEGORIES_PATH),
+                latest_batch.id
             ))
             .query(&[("lang", normalized_lang.as_str())])
             .send()
@@ -248,7 +245,9 @@ pub async fn execute_news(
         client
             .get(format!(
                 "{}/{}/categories/{}/stories",
-                KAGI_NEWS_BATCH_CATEGORIES_URL, latest_batch.id, category.id
+                http::kagi_news_url(KAGI_NEWS_BATCH_CATEGORIES_PATH),
+                latest_batch.id,
+                category.id
             ))
             .query(&[
                 ("limit", limit.to_string()),
@@ -304,7 +303,7 @@ pub async fn execute_news_categories(lang: &str) -> Result<NewsCategoriesRespons
     let normalized_lang = normalize_news_lang(lang);
     let latest_batch: NewsLatestBatch = decode_kagi_free_json(
         client
-            .get(KAGI_NEWS_LATEST_URL)
+            .get(http::kagi_news_url(KAGI_NEWS_LATEST_PATH))
             .query(&[("lang", normalized_lang.as_str())])
             .send()
             .await
@@ -314,7 +313,7 @@ pub async fn execute_news_categories(lang: &str) -> Result<NewsCategoriesRespons
     .await?;
     let metadata: NewsCategoryMetadataList = decode_kagi_free_json(
         client
-            .get(KAGI_NEWS_CATEGORIES_METADATA_URL)
+            .get(http::kagi_news_url(KAGI_NEWS_CATEGORIES_METADATA_PATH))
             .send()
             .await
             .map_err(map_transport_error)?,
@@ -325,7 +324,8 @@ pub async fn execute_news_categories(lang: &str) -> Result<NewsCategoriesRespons
         client
             .get(format!(
                 "{}/{}/categories",
-                KAGI_NEWS_BATCH_CATEGORIES_URL, latest_batch.id
+                http::kagi_news_url(KAGI_NEWS_BATCH_CATEGORIES_PATH),
+                latest_batch.id
             ))
             .query(&[("lang", normalized_lang.as_str())])
             .send()
@@ -359,7 +359,7 @@ pub async fn execute_news_chaos(lang: &str) -> Result<NewsChaosResponse, KagiErr
     let normalized_lang = normalize_news_lang(lang);
     let latest_batch: NewsLatestBatch = decode_kagi_free_json(
         client
-            .get(KAGI_NEWS_LATEST_URL)
+            .get(http::kagi_news_url(KAGI_NEWS_LATEST_PATH))
             .query(&[("lang", normalized_lang.as_str())])
             .send()
             .await
@@ -371,7 +371,8 @@ pub async fn execute_news_chaos(lang: &str) -> Result<NewsChaosResponse, KagiErr
         client
             .get(format!(
                 "{}/{}/chaos",
-                KAGI_NEWS_BATCH_CATEGORIES_URL, latest_batch.id
+                http::kagi_news_url(KAGI_NEWS_BATCH_CATEGORIES_PATH),
+                latest_batch.id
             ))
             .query(&[("lang", normalized_lang.as_str())])
             .send()
@@ -395,7 +396,7 @@ pub async fn execute_assistant_prompt(
     let thread_id = normalize_assistant_thread_id(request.thread_id.as_deref())?;
     let profile = assistant_profile_payload(request);
     let body = execute_assistant_stream(
-        KAGI_ASSISTANT_PROMPT_URL,
+        &http::kagi_url(KAGI_ASSISTANT_PROMPT_PATH),
         &json!({
             "focus": {
                 "thread_id": thread_id,
@@ -417,7 +418,7 @@ pub async fn execute_assistant_thread_list(
     token: &str,
 ) -> Result<AssistantThreadListResponse, KagiError> {
     let body = execute_assistant_stream(
-        KAGI_ASSISTANT_THREAD_LIST_URL,
+        &http::kagi_url(KAGI_ASSISTANT_THREAD_LIST_PATH),
         &json!({ "limit": 100 }),
         token,
         "Assistant thread list",
@@ -434,7 +435,7 @@ pub async fn execute_assistant_thread_get(
     let thread_id = normalize_assistant_thread_id(Some(thread_id))?
         .ok_or_else(|| KagiError::Config("assistant thread id cannot be empty".to_string()))?;
     let body = execute_assistant_stream(
-        KAGI_ASSISTANT_THREAD_OPEN_URL,
+        &http::kagi_url(KAGI_ASSISTANT_THREAD_OPEN_PATH),
         &json!({
             "focus": {
                 "thread_id": thread_id,
@@ -455,7 +456,7 @@ pub async fn execute_assistant_thread_delete(
 ) -> Result<AssistantThreadDeleteResponse, KagiError> {
     let thread = execute_assistant_thread_get(thread_id, token).await?.thread;
     let body = execute_assistant_stream(
-        KAGI_ASSISTANT_THREAD_DELETE_URL,
+        &http::kagi_url(KAGI_ASSISTANT_THREAD_DELETE_PATH),
         &json!({
             "threads": [{
                 "id": thread.id,
@@ -481,7 +482,7 @@ pub async fn execute_assistant_thread_export(
         .ok_or_else(|| KagiError::Config("assistant thread id cannot be empty".to_string()))?;
     let client = build_client()?;
     let response = client
-        .get(format!("https://kagi.com/assistant/{thread_id}/download"))
+        .get(http::kagi_url(&format!("/assistant/{thread_id}/download")))
         .header(header::COOKIE, format!("kagi_session={token}"))
         .send()
         .await
@@ -531,7 +532,7 @@ pub async fn execute_custom_assistant_list(
     token: &str,
 ) -> Result<Vec<AssistantProfileSummary>, KagiError> {
     let html = fetch_authenticated_html(
-        KAGI_SETTINGS_ASSISTANT_URL,
+        &http::kagi_url(KAGI_SETTINGS_ASSISTANT_PATH),
         token,
         "Assistant settings page",
     )
@@ -566,7 +567,7 @@ pub async fn execute_custom_assistant_create(
 ) -> Result<AssistantProfileDetails, KagiError> {
     let mut details = parse_assistant_profile_form(
         &fetch_authenticated_html(
-            KAGI_SETTINGS_CUSTOM_ASSISTANT_URL,
+            &http::kagi_url(KAGI_SETTINGS_CUSTOM_ASSISTANT_PATH),
             token,
             "new custom assistant form",
         )
@@ -593,7 +594,7 @@ pub async fn execute_custom_assistant_create(
     }
 
     let (url, _) = post_authenticated_form(
-        KAGI_SETTINGS_CUSTOM_ASSISTANT_UPDATE_URL,
+        &http::kagi_url(KAGI_SETTINGS_CUSTOM_ASSISTANT_UPDATE_PATH),
         &build_custom_assistant_form(&details),
         token,
         "custom assistant create",
@@ -636,7 +637,7 @@ pub async fn execute_custom_assistant_update(
     }
 
     post_authenticated_form(
-        KAGI_SETTINGS_CUSTOM_ASSISTANT_UPDATE_URL,
+        &http::kagi_url(KAGI_SETTINGS_CUSTOM_ASSISTANT_UPDATE_PATH),
         &build_custom_assistant_form(&details),
         token,
         "custom assistant update",
@@ -652,7 +653,7 @@ pub async fn execute_custom_assistant_delete(
     let assistants = execute_custom_assistant_list(token).await?;
     let assistant = resolve_custom_assistant_ref(&assistants, target, true)?;
     post_authenticated_form(
-        KAGI_SETTINGS_CUSTOM_ASSISTANT_DELETE_URL,
+        &http::kagi_url(KAGI_SETTINGS_CUSTOM_ASSISTANT_DELETE_PATH),
         &[("profile_id".to_string(), assistant.id.clone())],
         token,
         "custom assistant delete",
@@ -664,8 +665,12 @@ pub async fn execute_custom_assistant_delete(
 }
 
 pub async fn execute_lens_list(token: &str) -> Result<Vec<LensSummary>, KagiError> {
-    let html =
-        fetch_authenticated_html(KAGI_SETTINGS_LENSES_URL, token, "lens settings page").await?;
+    let html = fetch_authenticated_html(
+        &http::kagi_url(KAGI_SETTINGS_LENSES_PATH),
+        token,
+        "lens settings page",
+    )
+    .await?;
     parse_lens_list(&html)
 }
 
@@ -682,12 +687,17 @@ pub async fn execute_lens_create(
     token: &str,
 ) -> Result<LensDetails, KagiError> {
     let mut details = parse_lens_form(
-        &fetch_authenticated_html(KAGI_SETTINGS_CREATE_LENS_URL, token, "new lens form").await?,
+        &fetch_authenticated_html(
+            &http::kagi_url(KAGI_SETTINGS_CREATE_LENS_PATH),
+            token,
+            "new lens form",
+        )
+        .await?,
     )?;
     apply_lens_create_request(&mut details, request)?;
 
     let (url, _) = post_authenticated_form(
-        KAGI_LENSES_CREATE_URL,
+        &http::kagi_url(KAGI_LENSES_CREATE_PATH),
         &build_lens_form(&details),
         token,
         "lens create",
@@ -710,7 +720,7 @@ pub async fn execute_lens_update(
     apply_lens_update_request(&mut details, request)?;
 
     post_authenticated_form(
-        KAGI_LENSES_UPDATE_URL,
+        &http::kagi_url(KAGI_LENSES_UPDATE_PATH),
         &build_lens_form(&details),
         token,
         "lens update",
@@ -726,7 +736,7 @@ pub async fn execute_lens_delete(
     let lenses = execute_lens_list(token).await?;
     let lens = resolve_lens_ref(&lenses, target)?;
     post_authenticated_form(
-        KAGI_LENSES_DELETE_URL,
+        &http::kagi_url(KAGI_LENSES_DELETE_PATH),
         &[("id".to_string(), lens.id.clone())],
         token,
         "lens delete",
@@ -752,7 +762,7 @@ pub async fn execute_lens_set_enabled(
     }
 
     post_authenticated_form(
-        KAGI_LENSES_SUBSCRIBE_URL,
+        &http::kagi_url(KAGI_LENSES_SUBSCRIBE_PATH),
         &[
             ("lens_id".to_string(), lens.id.clone()),
             (lens.toggle_field.clone(), lens.toggle_value.clone()),
@@ -775,8 +785,12 @@ pub async fn execute_lens_set_enabled(
 }
 
 pub async fn execute_custom_bang_list(token: &str) -> Result<Vec<CustomBangSummary>, KagiError> {
-    let html = fetch_authenticated_html(KAGI_SETTINGS_CUSTOM_BANGS_URL, token, "custom bangs page")
-        .await?;
+    let html = fetch_authenticated_html(
+        &http::kagi_url(KAGI_SETTINGS_CUSTOM_BANGS_PATH),
+        token,
+        "custom bangs page",
+    )
+    .await?;
     parse_custom_bang_list(&html)
 }
 
@@ -801,7 +815,7 @@ pub async fn execute_custom_bang_create(
 ) -> Result<CustomBangDetails, KagiError> {
     let mut details = parse_custom_bang_form(
         &fetch_authenticated_html(
-            KAGI_SETTINGS_CUSTOM_BANG_FORM_URL,
+            &http::kagi_url(KAGI_SETTINGS_CUSTOM_BANG_FORM_PATH),
             token,
             "new custom bang form",
         )
@@ -810,7 +824,7 @@ pub async fn execute_custom_bang_create(
     apply_custom_bang_create_request(&mut details, request)?;
 
     let (url, _) = post_authenticated_form(
-        KAGI_CUSTOM_BANGS_MODIFY_URL,
+        &http::kagi_url(KAGI_CUSTOM_BANGS_MODIFY_PATH),
         &build_custom_bang_form(&details, false),
         token,
         "custom bang create",
@@ -833,7 +847,7 @@ pub async fn execute_custom_bang_update(
     apply_custom_bang_update_request(&mut details, request)?;
 
     post_authenticated_form(
-        KAGI_CUSTOM_BANGS_MODIFY_URL,
+        &http::kagi_url(KAGI_CUSTOM_BANGS_MODIFY_PATH),
         &build_custom_bang_form(&details, false),
         token,
         "custom bang update",
@@ -851,7 +865,7 @@ pub async fn execute_custom_bang_delete(
     let details = execute_custom_bang_get(&bang.id, token).await?;
 
     post_authenticated_form(
-        KAGI_CUSTOM_BANGS_MODIFY_URL,
+        &http::kagi_url(KAGI_CUSTOM_BANGS_MODIFY_PATH),
         &build_custom_bang_form(&details, true),
         token,
         "custom bang delete",
@@ -863,8 +877,12 @@ pub async fn execute_custom_bang_delete(
 }
 
 pub async fn execute_redirect_list(token: &str) -> Result<Vec<RedirectRuleSummary>, KagiError> {
-    let html =
-        fetch_authenticated_html(KAGI_SETTINGS_REDIRECTS_URL, token, "redirects page").await?;
+    let html = fetch_authenticated_html(
+        &http::kagi_url(KAGI_SETTINGS_REDIRECTS_PATH),
+        token,
+        "redirects page",
+    )
+    .await?;
     parse_redirect_list(&html)
 }
 
@@ -891,7 +909,7 @@ pub async fn execute_redirect_create(
 ) -> Result<RedirectRuleDetails, KagiError> {
     let rule = normalize_redirect_rule(&request.rule)?;
     let (url, _) = post_authenticated_form(
-        KAGI_REDIRECTS_CREATE_UPDATE_URL,
+        &http::kagi_url(KAGI_REDIRECTS_CREATE_UPDATE_PATH),
         &[("regex".to_string(), rule.clone())],
         token,
         "redirect create",
@@ -911,7 +929,7 @@ pub async fn execute_redirect_update(
     let redirect = resolve_redirect_ref(&redirects, &request.target)?;
     let rule = normalize_redirect_rule(&request.rule)?;
     post_authenticated_form(
-        KAGI_REDIRECTS_CREATE_UPDATE_URL,
+        &http::kagi_url(KAGI_REDIRECTS_CREATE_UPDATE_PATH),
         &[
             ("rule_id".to_string(), redirect.id.clone()),
             ("regex".to_string(), rule),
@@ -930,7 +948,7 @@ pub async fn execute_redirect_delete(
     let redirects = execute_redirect_list(token).await?;
     let redirect = resolve_redirect_ref(&redirects, target)?;
     post_authenticated_form(
-        KAGI_REDIRECTS_DELETE_URL,
+        &http::kagi_url(KAGI_REDIRECTS_DELETE_PATH),
         &[("rule_id".to_string(), redirect.id.clone())],
         token,
         "redirect delete",
@@ -956,7 +974,7 @@ pub async fn execute_redirect_set_enabled(
     }
 
     post_authenticated_form(
-        KAGI_REDIRECTS_TOGGLE_URL,
+        &http::kagi_url(KAGI_REDIRECTS_TOGGLE_PATH),
         &[("rule_id".to_string(), redirect.id.clone())],
         token,
         if enabled {
@@ -1142,7 +1160,7 @@ pub async fn execute_fastgpt(
 
     let client = build_client()?;
     let response = client
-        .post(KAGI_FASTGPT_URL)
+        .post(http::kagi_url(KAGI_FASTGPT_PATH))
         .header(header::AUTHORIZATION, format!("Bot {token}"))
         .header(header::CONTENT_TYPE, "application/json")
         .json(request)
@@ -1154,16 +1172,28 @@ pub async fn execute_fastgpt(
 }
 
 pub async fn execute_enrich_web(query: &str, token: &str) -> Result<EnrichResponse, KagiError> {
-    execute_enrich(KAGI_ENRICH_WEB_URL, query, token, "web enrichment").await
+    execute_enrich(
+        &http::kagi_url(KAGI_ENRICH_WEB_PATH),
+        query,
+        token,
+        "web enrichment",
+    )
+    .await
 }
 
 pub async fn execute_enrich_news(query: &str, token: &str) -> Result<EnrichResponse, KagiError> {
-    execute_enrich(KAGI_ENRICH_NEWS_URL, query, token, "news enrichment").await
+    execute_enrich(
+        &http::kagi_url(KAGI_ENRICH_NEWS_PATH),
+        query,
+        token,
+        "news enrichment",
+    )
+    .await
 }
 
 pub async fn execute_smallweb(limit: Option<u32>) -> Result<SmallWebFeed, KagiError> {
     let client = build_client()?;
-    let mut request = client.get(KAGI_SMALLWEB_FEED_URL);
+    let mut request = client.get(http::kagi_url(KAGI_SMALLWEB_FEED_PATH));
     if let Some(limit) = limit {
         request = request.query(&[("limit", limit)]);
     }
@@ -1218,7 +1248,7 @@ async fn bootstrap_translate_session(
 
     for attempt in 0..TRANSLATE_BOOTSTRAP_MAX_ATTEMPTS {
         let response = client
-            .get("https://translate.kagi.com/")
+            .get(http::kagi_translate_url("/"))
             .header(header::COOKIE, format!("kagi_session={session_token}"))
             .send()
             .await
@@ -1248,7 +1278,7 @@ async fn execute_translate_detect(
     text: &str,
 ) -> Result<TranslateDetectedLanguage, KagiError> {
     let response = client
-        .post(KAGI_TRANSLATE_DETECT_URL)
+        .post(http::kagi_translate_url(KAGI_TRANSLATE_DETECT_PATH))
         .header(header::COOKIE, cookie_header)
         .header(header::CONTENT_TYPE, "application/json")
         .json(&json!({
@@ -1271,7 +1301,7 @@ async fn execute_translate_text(
     effective_source_language: &str,
 ) -> Result<TranslateTextResponse, KagiError> {
     let response = client
-        .post(KAGI_TRANSLATE_URL)
+        .post(http::kagi_translate_url(KAGI_TRANSLATE_PATH))
         .header(header::COOKIE, cookie_header)
         .header(header::CONTENT_TYPE, "application/json")
         .json(&build_translate_payload(
@@ -1330,7 +1360,7 @@ async fn execute_translate_alternatives(
     }
 
     let response = client
-        .post(KAGI_TRANSLATE_ALTERNATIVES_URL)
+        .post(http::kagi_translate_url(KAGI_TRANSLATE_ALTERNATIVES_PATH))
         .header(header::COOKIE, cookie_header)
         .header(header::CONTENT_TYPE, "application/json")
         .json(&Value::Object(payload))
@@ -1349,7 +1379,7 @@ async fn execute_translate_text_alignments(
     target_text: &str,
 ) -> Result<TextAlignmentsResponse, KagiError> {
     let response = client
-        .post(KAGI_TRANSLATE_ALIGNMENTS_URL)
+        .post(http::kagi_translate_url(KAGI_TRANSLATE_ALIGNMENTS_PATH))
         .header(header::COOKIE, cookie_header)
         .header(header::CONTENT_TYPE, "application/json")
         .json(&json!({
@@ -1379,7 +1409,7 @@ async fn execute_translate_suggestions(
     context: TranslateSuggestionContext<'_>,
 ) -> Result<TranslationSuggestionsResponse, KagiError> {
     let response = client
-        .post(KAGI_TRANSLATE_SUGGESTIONS_URL)
+        .post(http::kagi_translate_url(KAGI_TRANSLATE_SUGGESTIONS_PATH))
         .header(header::COOKIE, cookie_header)
         .header(header::CONTENT_TYPE, "application/json")
         .json(&build_translate_suggestions_payload(context, translate_session).map(Value::Object)?)
@@ -1400,7 +1430,7 @@ async fn execute_translate_word_insights(
     translation_options: Option<&TranslateOptionState>,
 ) -> Result<WordInsightsResponse, KagiError> {
     let response = client
-        .post(KAGI_TRANSLATE_WORD_INSIGHTS_URL)
+        .post(http::kagi_translate_url(KAGI_TRANSLATE_WORD_INSIGHTS_PATH))
         .header(header::COOKIE, cookie_header)
         .header(header::CONTENT_TYPE, "application/json")
         .json(
@@ -1961,7 +1991,7 @@ fn absolute_kagi_url(path: &str) -> String {
     if path.starts_with("http://") || path.starts_with("https://") {
         path.to_string()
     } else {
-        format!("https://kagi.com{path}")
+        http::kagi_url(path)
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -11,6 +11,13 @@ const USER_AGENT: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     " (+https://github.com/Microck/kagi-cli)"
 );
+const DEFAULT_KAGI_BASE_URL: &str = "https://kagi.com";
+const DEFAULT_KAGI_NEWS_BASE_URL: &str = "https://news.kagi.com";
+const DEFAULT_KAGI_TRANSLATE_BASE_URL: &str = "https://translate.kagi.com";
+
+pub const KAGI_BASE_URL_ENV: &str = "KAGI_BASE_URL";
+pub const KAGI_NEWS_BASE_URL_ENV: &str = "KAGI_NEWS_BASE_URL";
+pub const KAGI_TRANSLATE_BASE_URL_ENV: &str = "KAGI_TRANSLATE_BASE_URL";
 
 static CLIENT_20S: OnceLock<Result<Client, String>> = OnceLock::new();
 static CLIENT_30S: OnceLock<Result<Client, String>> = OnceLock::new();
@@ -45,6 +52,27 @@ pub async fn read_error_body(response: Response, surface: &str) -> String {
     }
 }
 
+pub fn kagi_url(path: &str) -> String {
+    build_url(
+        &base_url_from_env(KAGI_BASE_URL_ENV, DEFAULT_KAGI_BASE_URL),
+        path,
+    )
+}
+
+pub fn kagi_news_url(path: &str) -> String {
+    build_url(
+        &base_url_from_env(KAGI_NEWS_BASE_URL_ENV, DEFAULT_KAGI_NEWS_BASE_URL),
+        path,
+    )
+}
+
+pub fn kagi_translate_url(path: &str) -> String {
+    build_url(
+        &base_url_from_env(KAGI_TRANSLATE_BASE_URL_ENV, DEFAULT_KAGI_TRANSLATE_BASE_URL),
+        path,
+    )
+}
+
 fn cached_client(
     slot: &OnceLock<Result<Client, String>>,
     timeout: Duration,
@@ -61,4 +89,81 @@ fn cached_client(
         .as_ref()
         .cloned()
         .map_err(|error| KagiError::Network(error.clone()))
+}
+
+fn base_url_from_env(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn build_url(base: &str, path: &str) -> String {
+    if path.starts_with("http://") || path.starts_with("https://") {
+        return path.to_string();
+    }
+
+    if path.starts_with('/') {
+        format!("{}{}", base.trim_end_matches('/'), path)
+    } else {
+        format!("{}/{}", base.trim_end_matches('/'), path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        KAGI_BASE_URL_ENV, KAGI_NEWS_BASE_URL_ENV, KAGI_TRANSLATE_BASE_URL_ENV, kagi_news_url,
+        kagi_translate_url, kagi_url,
+    };
+
+    fn set_env_var(key: &str, value: &str) {
+        unsafe { std::env::set_var(key, value) }
+    }
+
+    fn remove_env_var(key: &str) {
+        unsafe { std::env::remove_var(key) }
+    }
+
+    #[test]
+    fn builds_default_urls() {
+        remove_env_var(KAGI_BASE_URL_ENV);
+        remove_env_var(KAGI_NEWS_BASE_URL_ENV);
+        remove_env_var(KAGI_TRANSLATE_BASE_URL_ENV);
+
+        assert_eq!(kagi_url("/api/v0/search"), "https://kagi.com/api/v0/search");
+        assert_eq!(
+            kagi_news_url("/api/batches/latest"),
+            "https://news.kagi.com/api/batches/latest"
+        );
+        assert_eq!(
+            kagi_translate_url("/api/translate"),
+            "https://translate.kagi.com/api/translate"
+        );
+    }
+
+    #[test]
+    fn honors_base_url_overrides() {
+        set_env_var(KAGI_BASE_URL_ENV, "http://127.0.0.1:9000/");
+        set_env_var(KAGI_NEWS_BASE_URL_ENV, "http://127.0.0.1:9001/");
+        set_env_var(KAGI_TRANSLATE_BASE_URL_ENV, "http://127.0.0.1:9002/");
+
+        assert_eq!(
+            kagi_url("/api/v0/search"),
+            "http://127.0.0.1:9000/api/v0/search"
+        );
+        assert_eq!(
+            kagi_news_url("/api/batches/latest"),
+            "http://127.0.0.1:9001/api/batches/latest"
+        );
+        assert_eq!(
+            kagi_translate_url("/api/translate"),
+            "http://127.0.0.1:9002/api/translate"
+        );
+
+        remove_env_var(KAGI_BASE_URL_ENV);
+        remove_env_var(KAGI_NEWS_BASE_URL_ENV);
+        remove_env_var(KAGI_TRANSLATE_BASE_URL_ENV);
+    }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -7,8 +7,8 @@ use crate::http::{self, map_transport_error};
 use crate::parser::parse_search_results;
 use crate::types::{SearchResponse, SearchResult};
 
-const KAGI_SEARCH_URL: &str = "https://kagi.com/html/search";
-const KAGI_API_SEARCH_URL: &str = "https://kagi.com/api/v0/search";
+const KAGI_SEARCH_PATH: &str = "/html/search";
+const KAGI_API_SEARCH_PATH: &str = "/api/v0/search";
 const UNAUTHENTICATED_MARKERS: [&str; 3] = [
     "<title>Kagi Search - A Premium Search Engine</title>",
     "Welcome to Kagi",
@@ -197,7 +197,7 @@ pub async fn search_with_lens(request: &SearchRequest, token: &str) -> Result<St
     let query_params = build_search_query_params(request)?;
 
     let response = client
-        .get(KAGI_SEARCH_URL)
+        .get(http::kagi_url(KAGI_SEARCH_PATH))
         .query(&query_params)
         .header(header::COOKIE, format!("kagi_session={token}"))
         .send()
@@ -248,7 +248,7 @@ pub async fn execute_api_search(
 
     let client = build_client()?;
     let response = client
-        .get(KAGI_API_SEARCH_URL)
+        .get(http::kagi_url(KAGI_API_SEARCH_PATH))
         .query(&[("q", request.query.trim())])
         .header(header::AUTHORIZATION, format!("Bot {token}"))
         .send()

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -1,0 +1,422 @@
+use std::path::Path;
+use std::process::{Command, Output};
+
+use httpmock::Method::{GET, POST};
+use httpmock::MockServer;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+const API_TOKEN: &str = "test-api-token";
+
+fn run_kagi(args: &[&str], envs: &[(&str, &str)], cwd: &Path) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kagi"));
+    command.args(args).current_dir(cwd);
+
+    for key in [
+        "KAGI_API_TOKEN",
+        "KAGI_SESSION_TOKEN",
+        "KAGI_BASE_URL",
+        "KAGI_NEWS_BASE_URL",
+        "KAGI_TRANSLATE_BASE_URL",
+    ] {
+        command.env_remove(key);
+    }
+
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+
+    command.output().expect("command should run")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "expected success, got status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn test_env(server: &MockServer) -> Vec<(&'static str, String)> {
+    vec![
+        ("KAGI_API_TOKEN", API_TOKEN.to_string()),
+        ("KAGI_BASE_URL", server.base_url()),
+        ("KAGI_NEWS_BASE_URL", server.base_url()),
+    ]
+}
+
+fn env_refs(values: &[(impl AsRef<str>, impl AsRef<str>)]) -> Vec<(&str, &str)> {
+    values
+        .iter()
+        .map(|(key, value)| (key.as_ref(), value.as_ref()))
+        .collect()
+}
+
+fn api_meta() -> Value {
+    json!({
+        "id": "req-1",
+        "node": "test",
+        "ms": 12
+    })
+}
+
+fn search_payload(title: &str, url: &str, snippet: &str) -> Value {
+    json!({
+        "meta": api_meta(),
+        "data": [
+            {
+                "t": 0,
+                "url": url,
+                "title": title,
+                "snippet": snippet
+            }
+        ]
+    })
+}
+
+fn news_latest_batch() -> Value {
+    json!({
+        "createdAt": "2026-04-06T00:00:00Z",
+        "dateSlug": "2026-04-06",
+        "id": "batch-1",
+        "languageCode": "en",
+        "processingTime": 14,
+        "totalArticles": 120,
+        "totalCategories": 8,
+        "totalClusters": 64,
+        "totalReadCount": 90
+    })
+}
+
+fn news_category_metadata() -> Value {
+    json!({
+        "categories": [
+            {
+                "categoryId": "tech",
+                "categoryType": "topic",
+                "displayName": "Tech",
+                "isCore": true,
+                "sourceLanguage": "en"
+            }
+        ]
+    })
+}
+
+fn news_batch_categories() -> Value {
+    json!({
+        "batchId": "batch-1",
+        "createdAt": "2026-04-06T00:00:00Z",
+        "hasOnThisDay": false,
+        "categories": [
+            {
+                "id": "category-1",
+                "categoryId": "tech",
+                "categoryName": "Tech",
+                "sourceLanguage": "en",
+                "timestamp": 1712361600,
+                "readCount": 42,
+                "clusterCount": 3
+            }
+        ]
+    })
+}
+
+fn news_stories() -> Value {
+    json!({
+        "batchId": "batch-1",
+        "categoryId": "tech",
+        "categoryName": "Tech",
+        "timestamp": 1712361600,
+        "stories": [
+            {
+                "title": "Rust ships new release",
+                "url": "https://example.com/rust-release"
+            }
+        ],
+        "totalStories": "1",
+        "domains": [],
+        "readCount": 10
+    })
+}
+
+#[test]
+fn search_command_returns_json_from_mock_api() {
+    let server = MockServer::start();
+    let _search = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/v0/search")
+            .query_param("q", "rust programming")
+            .header("authorization", "Bot test-api-token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(search_payload(
+                "Rust Programming Language",
+                "https://www.rust-lang.org",
+                "Reliable systems programming.",
+            ));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = test_env(&server);
+    let output = run_kagi(
+        &["search", "rust programming", "--format", "json"],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["data"][0]["title"], "Rust Programming Language");
+}
+
+#[test]
+fn search_command_pretty_format_prints_ranked_results() {
+    let server = MockServer::start();
+    let _search = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/v0/search")
+            .query_param("q", "rust programming")
+            .header("authorization", "Bot test-api-token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(search_payload(
+                "Rust Book",
+                "https://doc.rust-lang.org/book/",
+                "Learn Rust with the official book.",
+            ));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = test_env(&server);
+    let output = run_kagi(
+        &[
+            "search",
+            "rust programming",
+            "--format",
+            "pretty",
+            "--no-color",
+        ],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("1. Rust Book"));
+    assert!(stdout.contains("https://doc.rust-lang.org/book/"));
+    assert!(stdout.contains("Learn Rust with the official book."));
+}
+
+#[test]
+fn batch_command_returns_queries_and_results() {
+    let server = MockServer::start();
+    let _rust = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/v0/search")
+            .query_param("q", "rust")
+            .header("authorization", "Bot test-api-token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(search_payload(
+                "Rust",
+                "https://www.rust-lang.org",
+                "Rust homepage.",
+            ));
+    });
+    let _zig = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/v0/search")
+            .query_param("q", "zig")
+            .header("authorization", "Bot test-api-token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(search_payload(
+                "Zig",
+                "https://ziglang.org",
+                "Zig homepage.",
+            ));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = test_env(&server);
+    let output = run_kagi(
+        &[
+            "batch",
+            "rust",
+            "zig",
+            "--format",
+            "json",
+            "--concurrency",
+            "2",
+            "--rate-limit",
+            "60",
+        ],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["queries"], json!(["rust", "zig"]));
+    assert_eq!(body["results"][0]["data"][0]["title"], "Rust");
+    assert_eq!(body["results"][1]["data"][0]["title"], "Zig");
+}
+
+#[test]
+fn batch_command_reports_partial_failures_in_json_mode() {
+    let server = MockServer::start();
+    let _ok = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/v0/search")
+            .query_param("q", "rust")
+            .header("authorization", "Bot test-api-token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(search_payload(
+                "Rust",
+                "https://www.rust-lang.org",
+                "Rust homepage.",
+            ));
+    });
+    let _fail = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/v0/search")
+            .query_param("q", "broken")
+            .header("authorization", "Bot test-api-token");
+        then.status(403)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "error": [{ "msg": "Insufficient credit" }]
+            }));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = test_env(&server);
+    let output = run_kagi(
+        &[
+            "batch",
+            "rust",
+            "broken",
+            "--format",
+            "json",
+            "--concurrency",
+            "2",
+            "--rate-limit",
+            "60",
+        ],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert!(!output.status.success(), "batch command should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("One or more batch queries failed"));
+}
+
+#[test]
+fn auth_check_validates_credentials_without_live_network() {
+    let server = MockServer::start();
+    let _search = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/v0/search")
+            .query_param("q", "rust lang")
+            .header("authorization", "Bot test-api-token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(search_payload(
+                "Rust",
+                "https://www.rust-lang.org",
+                "Rust homepage.",
+            ));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = test_env(&server);
+    let output = run_kagi(&["auth", "check"], &env_refs(&env), tempdir.path());
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("auth check passed: api-token (env)"));
+}
+
+#[test]
+fn summarize_url_command_prints_structured_json() {
+    let server = MockServer::start();
+    let _summarize = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/v0/summarize")
+            .header("authorization", "Bot test-api-token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "meta": api_meta(),
+                "data": {
+                    "output": "A concise summary.",
+                    "tokens": 42
+                }
+            }));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = test_env(&server);
+    let output = run_kagi(
+        &["summarize", "--url", "https://example.com/article"],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["data"]["output"], "A concise summary.");
+}
+
+#[test]
+fn news_command_resolves_category_and_prints_json() {
+    let server = MockServer::start();
+    let _latest = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/batches/latest")
+            .query_param("lang", "en");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(news_latest_batch());
+    });
+    let _metadata = server.mock(|when, then| {
+        when.method(GET).path("/api/categories/metadata");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(news_category_metadata());
+    });
+    let _categories = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/batches/batch-1/categories")
+            .query_param("lang", "en");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(news_batch_categories());
+    });
+    let _stories = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/batches/batch-1/categories/category-1/stories")
+            .query_param("limit", "12")
+            .query_param("lang", "en");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(news_stories());
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = test_env(&server);
+    let output = run_kagi(
+        &["news", "--category", "tech", "--lang", "en"],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["category"]["category_name"], "Tech");
+    assert_eq!(body["stories"][0]["title"], "Rust ships new release");
+}


### PR DESCRIPTION
**Summary**
- add env-driven base URL overrides for Kagi, Kagi News, and Kagi Translate endpoints
- add mocked end-to-end CLI integration tests with `httpmock`
- cover `search`, `batch`, `auth check`, `summarize`, and `news` without live credentials

**Verification**
- `cargo test --test integration-cli`
- `cargo test`

**Issue**
- closes #38