### PR TITLE
[nightshift] release-notes: draft changelog + release notes for unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Added
+
+- Golden-path integration test coverage for CLI commands (lens, bangs, redirects, saved-assistant) with mocked HTTP responses
+
+### Changed
+
+- CI workflows now use concurrency groups to cancel redundant runs on the same branch
+
 ## [0.4.1]
 
 ### Added

--- a/docs/release-notes-unreleased.md
+++ b/docs/release-notes-unreleased.md
@@ -1,0 +1,25 @@
+# Release Notes — Unreleased (since v0.4.1)
+
+**Date:** Pending
+**Status:** Unreleased
+
+## Summary
+
+Two changes have landed on `main` since the v0.4.1 release:
+
+1. **Golden-path CLI integration tests** — New mocked HTTP test coverage for lens management, custom bangs, redirects, and saved-assistant selection commands.
+2. **CI concurrency groups** — All four CI workflows now use `concurrency` groups to cancel redundant in-flight runs when a new push arrives on the same branch.
+
+## Changes
+
+### Testing
+
+- Added golden-path integration tests for CLI commands with mocked HTTP responses, covering lens, bangs, redirects, and saved-assistant flows. (faa7346)
+
+### CI/CD
+
+- Added concurrency groups to all four GitHub Actions workflows, reducing wasted CI minutes by auto-cancelling superseded runs. (c03d6ea)
+
+---
+
+*These notes were drafted by [Nightshift](https://github.com/nightshift-micr) from `git log v0.4.1..HEAD`.*


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** Release Note Drafter  
**Category:** PR  
**Changes:**
- Updated CHANGELOG.md [Unreleased] section with golden-path CLI test coverage and CI concurrency group changes since v0.4.1
- Added `docs/release-notes-unreleased.md` with detailed release notes

Merge if useful, close if not.