### PR TITLE
fix: make expires_at optional in assistant thread payload

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3386,7 +3386,8 @@ struct AssistantThreadPayload {
     title: String,
     ack: String,
     created_at: String,
-    expires_at: String,
+    #[serde(default)]
+    expires_at: Option<String>,
     saved: bool,
     shared: bool,
     branch_id: String,
@@ -3401,7 +3402,7 @@ impl From<AssistantThreadPayload> for AssistantThread {
             title: payload.title,
             ack: payload.ack,
             created_at: payload.created_at,
-            expires_at: payload.expires_at,
+            expires_at: payload.expires_at.unwrap_or_default(),
             saved: payload.saved,
             shared: payload.shared,
             branch_id: payload.branch_id,

--- a/src/types.rs
+++ b/src/types.rs
@@ -295,6 +295,7 @@ pub struct AssistantThread {
     pub title: String,
     pub ack: String,
     pub created_at: String,
+    #[serde(default)]
     pub expires_at: String,
     pub saved: bool,
     pub shared: bool,


### PR DESCRIPTION
Closes #34

Kagi stopped sending `expires_at` in the `thread.json` stream frame. The `AssistantThreadPayload` struct in `src/api.rs` has it as a required `String`, so serde blows up.

**Fix (3 lines):**

- `src/api.rs` — change `expires_at: String` to `#[serde(default)] expires_at: Option<String>` and update the `From` impl to use `payload.expires_at.unwrap_or_default()`
- `src/types.rs` — add `#[serde(default)]` above `pub expires_at: String`

Build and all 156 tests pass.