### PR TITLE
fix(docs): correct broken image paths, auth-matrix inaccuracies, and MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ how to get it:
 3. click `Account` in the left sidebar
 4. in `Session Link`, click `Copy`
 
-![session-link tutorial](images/tutorials/session-link.gif)
+![session-link tutorial](images/demos/session-link.gif)
 
 ```bash
 kagi auth set --session-token 'https://kagi.com/search?token=...'
@@ -112,7 +112,7 @@ how to get it:
 4. go into `Open API Portal`
 5. under `API Token`, click `Generate New Token`
 
-![api token tutorial](images/tutorials/api-token.gif)
+![api token tutorial](images/demos/api-token.gif)
 
 ```bash
 export KAGI_API_TOKEN='...'

--- a/docs/guides/installation.mdx
+++ b/docs/guides/installation.mdx
@@ -263,7 +263,7 @@ For developers who want to modify the code or build for an unsupported platform.
 
 ### Prerequisites
 
-- Rust toolchain 1.70 or later
+- Rust toolchain 1.85 or later
 - Git
 - Network connectivity for dependencies
 

--- a/docs/reference/auth-matrix.mdx
+++ b/docs/reference/auth-matrix.mdx
@@ -116,7 +116,7 @@ flowchart TD
 
 - **Purpose:** Validate credentials work
 - **Network:** Yes (test search)
-- **Uses:** Primary credential (API if available, else session)
+- **Uses:** Primary credential per `[auth.preferred_auth]` setting (defaults to session token)
 - **No fallback:** Tests primary credential only
 
 #### `kagi auth set`
@@ -325,7 +325,7 @@ kagi auth set --session-token '...' --api-token '...'
 - ✅ Everything listed above
 
 **Smart behavior:**
-- `search`: Uses API (preferred), falls back to session if needed
+- `search`: Uses session (default), or API if `[auth.preferred_auth = "api"]` is set
 - `summarize` without `--subscriber`: Uses API
 - `summarize --subscriber`: Uses session
 - `quick`: Uses session


### PR DESCRIPTION
Fixes actionable findings from #45:

- **README.md:** Fix broken tutorial GIF paths (`images/tutorials/` → `images/demos/`)
- **auth-matrix.mdx:** Fix `auth check` credential description — defaults to session-first, not API-first
- **auth-matrix.mdx:** Fix both-tokens search behavior — session is default, not API preferred
- **installation.mdx:** Fix Rust MSRV from 1.70 to 1.85 (edition 2024 requires 1.85+)

Closes #45