### PR TITLE
[nightshift] lint-fix: automated improvements

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1821,12 +1821,12 @@ fn text_contains_news_filter_keyword(text: &str, keyword: &str) -> bool {
         let start_ok = text[..index]
             .chars()
             .next_back()
-            .map_or(true, |ch| !is_news_filter_word_char(ch));
+            .is_none_or(|ch| !is_news_filter_word_char(ch));
         let end_index = index + keyword.len();
         let end_ok = text[end_index..]
             .chars()
             .next()
-            .map_or(true, |ch| !is_news_filter_word_char(ch));
+            .is_none_or(|ch| !is_news_filter_word_char(ch));
 
         if start_ok && end_ok {
             return true;


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** lint-fix
**Category:** pr
**Changes:** Fix 2 clippy warnings in src/api.rs: replace `.map_or(true, ...)` with `.is_none_or(...)` (Rust 1.82+ idiom). Zero clippy warnings after fix.

Merge if useful, close if not.