### PR TITLE
[nightshift] changelog-synth: populate Unreleased section from recent commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Added
+
+- Rust doc comments on all previously undocumented public functions across the crate
+
+### Fixed
+
+- Replaced `map_or` with `is_none_or` to resolve `clippy::unnecessary_map_or` lint
+- Corrected stale README badges, broken links, and missing documentation sections
+- Applied Clippy pedantic and nursery lint auto-fixes across the codebase
+
 ## [0.4.3]
 
 ### Fixed


### PR DESCRIPTION
Automated by **Nightshift v3** (GLM 5.1).

**Task:** changelog-synth
**Category:** pr
**Cost tier:** low

## Changes

Populated the `[Unreleased]` section in `CHANGELOG.md` with the 4 commits since `v0.4.3`:

**Added:**
- Rust doc comments on all previously undocumented public functions

**Fixed:**
- Replaced `map_or` with `is_none_or` (clippy fix)
- Corrected stale README badges, broken links, and missing docs sections
- Applied Clippy pedantic/nursery auto-fixes

---
*Merge if useful, close if not.*