### PR TITLE
[nightshift] ci-fixes: add timeout-minutes, persist-credentials, npm dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/npm"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   rust:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   publish:
+    timeout-minutes: 10
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
@@ -27,6 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.workflow_run.head_sha }}
 
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
 
@@ -70,12 +71,14 @@ jobs:
             archive_ext: zip
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -140,6 +143,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
 
@@ -148,6 +152,7 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+          persist-credentials: false
 
       - name: Download packaged archives
         uses: actions/download-artifact@v8.0.1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   cargo-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** ci-fixes
**Category:** pr

**Changes:**
- Added `timeout-minutes` to all workflow jobs (ci, coverage, security, release verify/build/release, npm-publish) to prevent indefinite hangs
- Added `persist-credentials: false` to checkout steps in release build, release release, and npm-publish workflows (already present in verify job)
- Added npm ecosystem to dependabot.yml for the `/npm` directory

All YAML validated. 6 files changed, 15 insertions.