### PR TITLE
[nightshift] changelog-synth: update Unreleased with CI workflow improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 ### Added
 
 - Rust doc comments on all previously undocumented public functions across the crate
+- `timeout-minutes` guards on CI, release, coverage, and security workflows to prevent hung runs
+- Dependabot configuration for the npm wrapper package
 
 ### Fixed
 
 - Replaced `map_or` with `is_none_or` to resolve `clippy::unnecessary_map_or` lint
 - Corrected stale README badges, broken links, and missing documentation sections
 - Applied Clippy pedantic and nursery lint auto-fixes across the codebase
+- `persist-credentials: false` on all checkout steps to avoid stale token leakage
 
 ## [0.4.3]
 


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** changelog-synth
**Category:** pr
**Changes:** Updated the [Unreleased] section of CHANGELOG.md with entries from recent commits since v0.4.3:
- Added `timeout-minutes` guards on CI, release, coverage, and security workflows
- Added Dependabot configuration for the npm wrapper package
- Added `persist-credentials: false` on all checkout steps

Merge if useful, close if not.