### PR TITLE
[nightshift] docs-backfill: add module and struct documentation

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,3 +1,9 @@
+//! Authentication and session management for the Kagi API.
+//!
+//! Handles loading API tokens from environment variables, config files,
+//! and the interactive authentication wizard. Provides session persistence
+//! via the filesystem.
+
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,9 @@
+//! Command-line interface definitions for kagi-cli.
+//!
+//! Uses `clap` to define the full CLI structure including subcommands
+//! (search, summarize, news, assistant, quick, etc.), global flags,
+//! and per-subcommand options.
+
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,19 +1,34 @@
+//! Error types for the kagi-cli crate.
+//!
+//! All fallible operations return [`KagiError`], which covers network,
+//! authentication, parsing, configuration, and batch processing failures.
+
 use thiserror::Error;
 
+/// Top-level error type for kagi-cli operations.
+///
+/// Each variant carries a human-readable description string. Convert specific
+/// upstream errors (e.g. `serde_json::Error`) into the appropriate variant
+/// using the provided `From` implementations.
 #[derive(Debug, Error)]
 pub enum KagiError {
+    /// A network-related failure (connection, timeout, DNS, HTTP status).
     #[error("network error: {0}")]
     Network(String),
 
+    /// An authentication or authorization failure (missing/invalid API key).
     #[error("authentication error: {0}")]
     Auth(String),
 
+    /// A data parsing or deserialization failure.
     #[error("parse error: {0}")]
     Parse(String),
 
+    /// A configuration error (missing env var, invalid settings).
     #[error("configuration error: {0}")]
     Config(String),
 
+    /// A batch operation error (parallel search failures).
     #[error("batch error: {0}")]
     Batch(String),
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,9 @@
+//! HTML parsing for Kagi search result pages.
+//!
+//! Extracts structured [`SearchResult`] values from the HTML markup returned
+//! by Kagi's web search endpoint. Also parses assistant profiles, threads,
+//! custom bangs, and lens details from their respective HTML pages.
+
 use scraper::{Html, Selector};
 
 use crate::error::KagiError;

--- a/src/quick.rs
+++ b/src/quick.rs
@@ -1,3 +1,9 @@
+//! Kagi "quick answer" API client.
+//!
+//! Provides the [`quick_answer`] function for fetching concise answers from
+//! the Kagi Quick Answer endpoint. Returns structured [`QuickResponse`] values
+//! with references and metadata.
+
 use reqwest::{Client, StatusCode, Url, header};
 use scraper::Html;
 use serde::Deserialize;

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,3 +1,9 @@
+//! Kagi search API client.
+//!
+//! Provides the [`search`] function for querying the Kagi HTML search endpoint
+//! and parsing results into structured [`SearchResponse`] values. Supports
+//! pagination, lenses, region selection, and time filtering.
+
 use reqwest::{Client, StatusCode, header};
 use serde::Deserialize;
 use tracing::debug;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,23 @@
+//! API request and response types for Kagi services.
+//!
+//! This module defines the data structures used across all Kagi API endpoints:
+//! search, summarization, news, assistant, lenses, and translation.
+//!
+//! Types are grouped by feature:
+//! - **Search**: [`SearchResult`], [`SearchResponse`]
+//! - **Summarization**: [`SummarizeRequest`], [`SummarizeResponse`], [`SubscriberSummarizeRequest`], [`SubscriberSummarizeResponse`]
+//! - **News**: [`NewsLatestBatch`], [`NewsCategoriesResponse`], [`NewsStoriesResponse`], [`NewsChaosResponse`]
+//! - **Assistant**: [`AssistantPromptRequest`], [`AssistantPromptResponse`], [`AssistantThread`], [`AssistantMessage`]
+//! - **Lenses**: [`LensSummary`], [`LensDetails`]
+//! - **Translation**: [`TranslateRequest`], [`TranslateResponse`]
+
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A single search result from the Kagi search API.
 pub struct SearchResult {
     pub t: u8,
     #[serde(default)]
@@ -17,11 +31,13 @@ pub struct SearchResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Wrapper for a list of search results.
 pub struct SearchResponse {
     pub data: Vec<SearchResult>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Metadata returned with most Kagi API responses (request ID, node, latency).
 pub struct ApiMeta {
     pub id: String,
     pub node: String,
@@ -29,6 +45,7 @@ pub struct ApiMeta {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Request body for the public API summarization endpoint.
 pub struct SummarizeRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -45,18 +62,21 @@ pub struct SummarizeRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// The summarization output from a public API request.
 pub struct Summarization {
     pub output: String,
     pub tokens: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response from the public API summarization endpoint.
 pub struct SummarizeResponse {
     pub meta: ApiMeta,
     pub data: Summarization,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+/// Metadata for the subscriber-mode summarization endpoint.
 pub struct SubscriberSummarizeMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
@@ -65,6 +85,7 @@ pub struct SubscriberSummarizeMeta {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Request body for the subscriber-mode summarization endpoint.
 pub struct SubscriberSummarizeRequest {
     pub url: Option<String>,
     pub text: Option<String>,
@@ -77,6 +98,7 @@ pub struct SubscriberSummarizeRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// The full summarization result from the subscriber endpoint.
 pub struct SubscriberSummarization {
     pub id: String,
     pub thread_id: String,
@@ -91,12 +113,14 @@ pub struct SubscriberSummarization {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response from the subscriber-mode summarization endpoint.
 pub struct SubscriberSummarizeResponse {
     pub meta: SubscriberSummarizeMeta,
     pub data: SubscriberSummarization,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Metadata about the latest processed news batch.
 pub struct NewsLatestBatch {
     #[serde(rename = "createdAt")]
     pub created_at: String,
@@ -118,6 +142,7 @@ pub struct NewsLatestBatch {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Metadata for a news category (ID, display name, language).
 pub struct NewsCategoryMetadata {
     #[serde(rename = "categoryId")]
     pub category_id: String,
@@ -132,11 +157,13 @@ pub struct NewsCategoryMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A list of news category metadata entries.
 pub struct NewsCategoryMetadataList {
     pub categories: Vec<NewsCategoryMetadata>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A category within a news batch (with read/cluster counts).
 pub struct NewsBatchCategory {
     pub id: String,
     #[serde(rename = "categoryId")]
@@ -153,6 +180,7 @@ pub struct NewsBatchCategory {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// All categories for a specific news batch.
 pub struct NewsBatchCategories {
     #[serde(rename = "batchId")]
     pub batch_id: String,
@@ -164,6 +192,7 @@ pub struct NewsBatchCategories {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A news category with resolved metadata.
 pub struct NewsResolvedCategory {
     pub id: String,
     pub category_id: String,
@@ -177,12 +206,14 @@ pub struct NewsResolvedCategory {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response containing the latest batch and its categories.
 pub struct NewsCategoriesResponse {
     pub latest_batch: NewsLatestBatch,
     pub categories: Vec<NewsResolvedCategory>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A single category payload within news stories.
 pub struct NewsStoriesPayload {
     #[serde(rename = "batchId")]
     pub batch_id: String,
@@ -201,6 +232,7 @@ pub struct NewsStoriesPayload {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response containing news stories for a category.
 pub struct NewsStoriesResponse {
     pub latest_batch: NewsLatestBatch,
     pub category: NewsResolvedCategory,
@@ -214,6 +246,7 @@ pub struct NewsStoriesResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// The Kagi News "chaos index" value and description.
 pub struct NewsChaos {
     #[serde(rename = "chaosIndex")]
     pub chaos_index: u64,
@@ -224,12 +257,14 @@ pub struct NewsChaos {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response containing the chaos index.
 pub struct NewsChaosResponse {
     pub latest_batch: NewsLatestBatch,
     pub chaos: NewsChaos,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A single filter preset entry (id, label, keywords).
 pub struct NewsFilterPresetListEntry {
     pub id: String,
     pub label: String,
@@ -237,12 +272,14 @@ pub struct NewsFilterPresetListEntry {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response listing available news filter presets.
 pub struct NewsFilterPresetListResponse {
     pub language: String,
     pub presets: Vec<NewsFilterPresetListEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Summary of active content filter settings for news.
 pub struct NewsContentFilterSummary {
     pub mode: String,
     pub scope: String,
@@ -253,12 +290,14 @@ pub struct NewsContentFilterSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Content filter summary for a single news story.
 pub struct NewsStoryContentFilterSummary {
     pub mode: String,
     pub matched_keywords: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+/// Metadata returned with assistant API responses.
 pub struct AssistantMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
@@ -267,6 +306,7 @@ pub struct AssistantMeta {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Request body for the assistant prompt endpoint.
 pub struct AssistantPromptRequest {
     pub query: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -284,12 +324,14 @@ pub struct AssistantPromptRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Request body for the "ask about a page" endpoint.
 pub struct AskPageRequest {
     pub url: String,
     pub question: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A conversation thread in the Kagi Assistant.
 pub struct AssistantThread {
     pub id: String,
     pub title: String,
@@ -305,6 +347,7 @@ pub struct AssistantThread {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A single message within an assistant thread.
 pub struct AssistantMessage {
     pub id: String,
     pub thread_id: String,
@@ -332,6 +375,7 @@ pub struct AssistantMessage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response from the assistant prompt endpoint.
 pub struct AssistantPromptResponse {
     pub meta: AssistantMeta,
     pub thread: AssistantThread,
@@ -339,12 +383,14 @@ pub struct AssistantPromptResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Source information for an "ask about a page" query.
 pub struct AskPageSource {
     pub url: String,
     pub question: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response from the "ask about a page" endpoint.
 pub struct AskPageResponse {
     pub meta: AssistantMeta,
     pub source: AskPageSource,
@@ -353,6 +399,7 @@ pub struct AskPageResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A summary view of an assistant thread (for listing).
 pub struct AssistantThreadSummary {
     pub id: String,
     pub title: String,
@@ -365,6 +412,7 @@ pub struct AssistantThreadSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Pagination info for thread list responses.
 pub struct AssistantThreadPagination {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
@@ -375,6 +423,7 @@ pub struct AssistantThreadPagination {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response listing assistant threads.
 pub struct AssistantThreadListResponse {
     pub meta: AssistantMeta,
     #[serde(default)]
@@ -384,6 +433,7 @@ pub struct AssistantThreadListResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response when opening a specific assistant thread.
 pub struct AssistantThreadOpenResponse {
     pub meta: AssistantMeta,
     #[serde(default)]
@@ -394,11 +444,13 @@ pub struct AssistantThreadOpenResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response confirming thread deletion.
 pub struct AssistantThreadDeleteResponse {
     pub deleted_thread_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response containing an exported thread as markdown.
 pub struct AssistantThreadExportResponse {
     pub thread_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -407,6 +459,7 @@ pub struct AssistantThreadExportResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Summary of an assistant profile.
 pub struct AssistantProfileSummary {
     pub id: String,
     pub name: String,
@@ -421,6 +474,7 @@ pub struct AssistantProfileSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Detailed view of an assistant profile configuration.
 pub struct AssistantProfileDetails {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_id: Option<String>,
@@ -436,6 +490,7 @@ pub struct AssistantProfileDetails {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request body for creating a new assistant profile.
 pub struct AssistantProfileCreateRequest {
     pub name: String,
     pub bang_trigger: Option<String>,
@@ -447,6 +502,7 @@ pub struct AssistantProfileCreateRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request body for updating an existing assistant profile.
 pub struct AssistantProfileUpdateRequest {
     pub target: String,
     pub name: Option<String>,
@@ -459,6 +515,7 @@ pub struct AssistantProfileUpdateRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Summary of a Kagi search lens.
 pub struct LensSummary {
     pub id: String,
     pub name: String,
@@ -475,6 +532,7 @@ pub struct LensSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Detailed configuration of a Kagi search lens.
 pub struct LensDetails {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** docs-backfill
**Category:** pr
**Changes:**

Added documentation to 7 source files:

- **error.rs**: Module-level docs + per-variant docs for `KagiError` enum (Network, Auth, Parse, Config, Batch)
- **types.rs**: Module-level docs with cross-references + 45 doc comments on public structs covering search, summarization, news, assistant, lens, and translation types
- **search.rs**: Module-level docs describing the search API client
- **quick.rs**: Module-level docs describing the quick answer API client
- **parser.rs**: Module-level docs describing HTML parsing
- **auth.rs**: Module-level docs describing authentication/session management
- **cli.rs**: Module-level docs describing CLI structure

103 lines of documentation added across 7 files. No code changes.

Merge if useful, close if not.