### PR TITLE
docs: add doc comments to 106 public items

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -93,6 +93,7 @@ const KAGI_LOGGED_OUT_MARKERS: [&str; 3] = [
 ];
 
 #[derive(Debug, Clone)]
+/// Filter parameters for the Kagi News API.
 pub struct NewsFilterRequest {
     pub preset_ids: Vec<String>,
     pub keywords: Vec<String>,
@@ -4085,6 +4086,7 @@ fn build_client() -> Result<Client, KagiError> {
 
 #[cfg(test)]
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+/// Generic wrapper for Kagi API responses containing a data payload.
 pub struct KagiEnvelope<T> {
     pub meta: ApiMeta,
     pub data: T,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -19,6 +19,7 @@ pub const API_TOKEN_ENV: &str = "KAGI_API_TOKEN";
 pub const SESSION_TOKEN_ENV: &str = "KAGI_SESSION_TOKEN";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The type of authentication credential.
 pub enum CredentialKind {
     ApiToken,
     SessionToken,
@@ -38,6 +39,7 @@ impl CredentialKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Where a credential was loaded from.
 pub enum CredentialSource {
     Env,
     Config,
@@ -57,6 +59,7 @@ impl CredentialSource {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Preferred authentication method for search operations.
 pub enum SearchAuthPreference {
     Session,
     Api,
@@ -86,6 +89,7 @@ impl SearchAuthPreference {
 }
 
 #[derive(Clone, PartialEq, Eq)]
+/// A resolved authentication credential with its kind and source.
 pub struct Credential {
     pub kind: CredentialKind,
     pub source: CredentialSource,
@@ -103,12 +107,14 @@ impl std::fmt::Debug for Credential {
 }
 
 #[derive(Debug, Clone)]
+/// Credentials resolved for a specific search request, with optional fallback.
 pub struct SearchCredentials {
     pub primary: Credential,
     pub fallback_session: Option<Credential>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Authentication requirement level for different search types.
 pub enum SearchAuthRequirement {
     Base,
     Lens,
@@ -116,6 +122,7 @@ pub enum SearchAuthRequirement {
 }
 
 #[derive(Debug, Clone)]
+/// All available credentials and preferences loaded from config and environment.
 pub struct CredentialInventory {
     pub api_token: Option<Credential>,
     pub session_token: Option<Credential>,
@@ -227,6 +234,7 @@ struct AuthConfig {
 }
 
 #[derive(Debug, Clone)]
+/// Snapshot of the current authentication configuration for display purposes.
 pub struct ConfigAuthSnapshot {
     pub config_path: PathBuf,
     pub api_token: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Clone, ValueEnum)]
+/// Supported shell types for tab-completion generation.
 pub enum CompletionShell {
     Bash,
     Zsh,
@@ -16,6 +17,7 @@ pub enum CompletionShell {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
+/// Output format for assistant thread exports.
 pub enum AssistantThreadExportFormat {
     Markdown,
     Json,
@@ -23,6 +25,7 @@ pub enum AssistantThreadExportFormat {
 
 /// Output format options for search results
 #[derive(Debug, Clone, ValueEnum)]
+/// Output format for search results.
 pub enum OutputFormat {
     /// JSON output (default) - structured data for scripts and APIs
     Json,
@@ -49,6 +52,7 @@ impl std::fmt::Display for OutputFormat {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
+/// Output format for quick answers.
 pub enum QuickOutputFormat {
     /// JSON output (default) - structured data for scripts and APIs
     Json,
@@ -72,6 +76,7 @@ impl std::fmt::Display for QuickOutputFormat {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
+/// Output format for assistant responses.
 pub enum AssistantOutputFormat {
     Json,
     Pretty,
@@ -91,6 +96,7 @@ impl std::fmt::Display for AssistantOutputFormat {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
+/// Sort order for search results.
 pub enum SearchOrder {
     Default,
     Recency,
@@ -99,6 +105,7 @@ pub enum SearchOrder {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
+/// Time range filter for search results.
 pub enum SearchTime {
     Day,
     Week,
@@ -107,6 +114,7 @@ pub enum SearchTime {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
+/// Predefined lens templates for common search scopes.
 pub enum LensTemplate {
     Default,
     News,
@@ -123,6 +131,7 @@ impl LensTemplate {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+/// News filtering mode (top stories vs. all).
 pub enum NewsFilterMode {
     Hide,
     Blur,
@@ -139,6 +148,7 @@ impl NewsFilterMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+/// Scope for news filtering (global, regional, etc.).
 pub enum NewsFilterScope {
     Title,
     Summary,
@@ -173,6 +183,7 @@ Features:
 )]
 #[command(disable_help_subcommand = true)]
 #[command(arg_required_else_help = true)]
+/// Top-level CLI definition with global flags and subcommands.
 pub struct Cli {
     /// Generate shell completion script and print to stdout
     #[arg(long, value_name = "SHELL", value_enum)]
@@ -183,6 +194,7 @@ pub struct Cli {
 }
 
 #[derive(Debug, Subcommand)]
+/// All available CLI subcommands.
 pub enum Commands {
     /// Search Kagi and emit structured JSON
     ///
@@ -235,6 +247,7 @@ pub enum Commands {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `search` subcommand.
 pub struct SearchArgs {
     /// Search query to send to Kagi
     #[arg(value_name = "QUERY", required = true)]
@@ -295,6 +308,7 @@ pub struct SearchArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `batch` subcommand (parallel search).
 pub struct BatchSearchArgs {
     /// List of search queries to execute in parallel
     #[arg(value_name = "QUERIES", required = true)]
@@ -374,12 +388,14 @@ impl BatchSearchArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `auth` command group.
 pub struct AuthCommand {
     #[command(subcommand)]
     pub command: AuthSubcommand,
 }
 
 #[derive(Debug, Subcommand)]
+/// Subcommands for authentication management.
 pub enum AuthSubcommand {
     /// Show which credential types are configured and where they come from
     Status,
@@ -390,6 +406,7 @@ pub enum AuthSubcommand {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for `auth set` (store a credential).
 pub struct AuthSetArgs {
     /// Kagi API token to save into .kagi.toml
     #[arg(long, value_name = "TOKEN")]
@@ -401,6 +418,7 @@ pub struct AuthSetArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `summarize` subcommand.
 pub struct SummarizeArgs {
     /// URL to summarize
     #[arg(long, value_name = "URL", conflicts_with = "text")]
@@ -450,6 +468,7 @@ impl SummarizeArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `fastgpt` subcommand.
 pub struct FastGptArgs {
     /// Query to answer
     #[arg(value_name = "QUERY")]
@@ -465,6 +484,7 @@ pub struct FastGptArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `news` subcommand.
 pub struct NewsArgs {
     /// News category slug (for example world, usa, tech, science)
     #[arg(long, value_name = "CATEGORY", default_value = "world")]
@@ -545,6 +565,7 @@ impl NewsArgs {
 
 #[derive(Debug, Args)]
 #[command(arg_required_else_help = true, args_conflicts_with_subcommands = true)]
+/// Arguments for the `assistant` subcommand.
 pub struct AssistantArgs {
     #[command(subcommand)]
     pub command: Option<AssistantSubcommand>,
@@ -595,6 +616,7 @@ pub struct AssistantArgs {
 }
 
 #[derive(Debug, Subcommand)]
+/// Subcommands for the assistant feature.
 pub enum AssistantSubcommand {
     /// Manage Assistant threads
     Thread(AssistantThreadArgs),
@@ -603,12 +625,14 @@ pub enum AssistantSubcommand {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for `assistant thread` management.
 pub struct AssistantThreadArgs {
     #[command(subcommand)]
     pub command: AssistantThreadSubcommand,
 }
 
 #[derive(Debug, Subcommand)]
+/// Subcommands for assistant thread operations.
 pub enum AssistantThreadSubcommand {
     /// List Assistant threads for the current account
     List,
@@ -621,6 +645,7 @@ pub enum AssistantThreadSubcommand {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for thread-specific operations (by ID).
 pub struct AssistantThreadIdArgs {
     /// Assistant thread id
     #[arg(value_name = "THREAD_ID")]
@@ -628,6 +653,7 @@ pub struct AssistantThreadIdArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for exporting an assistant thread.
 pub struct AssistantThreadExportArgs {
     /// Assistant thread id
     #[arg(value_name = "THREAD_ID")]
@@ -639,12 +665,14 @@ pub struct AssistantThreadExportArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for `assistant custom` (custom assistants).
 pub struct AssistantCustomArgs {
     #[command(subcommand)]
     pub command: AssistantCustomSubcommand,
 }
 
 #[derive(Debug, Subcommand)]
+/// Subcommands for custom assistant management.
 pub enum AssistantCustomSubcommand {
     /// List custom and built-in assistants visible to the account
     List,
@@ -659,6 +687,7 @@ pub enum AssistantCustomSubcommand {
 }
 
 #[derive(Debug, Args)]
+/// Arguments targeting a specific custom assistant.
 pub struct AssistantCustomTargetArgs {
     /// Custom assistant id or exact assistant name
     #[arg(value_name = "ID_OR_NAME")]
@@ -666,6 +695,7 @@ pub struct AssistantCustomTargetArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for creating a new custom assistant.
 pub struct AssistantCustomCreateArgs {
     /// Assistant name
     #[arg(value_name = "NAME")]
@@ -705,6 +735,7 @@ pub struct AssistantCustomCreateArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for updating an existing custom assistant.
 pub struct AssistantCustomUpdateArgs {
     /// Custom assistant id or exact assistant name
     #[arg(value_name = "ID_OR_NAME")]
@@ -748,6 +779,7 @@ pub struct AssistantCustomUpdateArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `ask-page` subcommand.
 pub struct AskPageArgs {
     /// Absolute page URL to discuss with Assistant
     #[arg(value_name = "URL")]
@@ -759,6 +791,7 @@ pub struct AskPageArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `translate` subcommand.
 pub struct TranslateArgs {
     /// Text to translate
     #[arg(value_name = "TEXT")]
@@ -854,6 +887,7 @@ pub struct TranslateArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `quick` subcommand (quick answers).
 pub struct QuickArgs {
     /// Query to answer with Kagi Quick Answer
     #[arg(value_name = "QUERY")]
@@ -873,12 +907,14 @@ pub struct QuickArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `enrich` command group.
 pub struct EnrichCommand {
     #[command(subcommand)]
     pub command: EnrichSubcommand,
 }
 
 #[derive(Debug, Subcommand)]
+/// Subcommands for web/news enrichment.
 pub enum EnrichSubcommand {
     /// Query Kagi's Teclis web enrichment index
     Web(EnrichArgs),
@@ -887,6 +923,7 @@ pub enum EnrichSubcommand {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for enrichment operations.
 pub struct EnrichArgs {
     /// Query to enrich
     #[arg(value_name = "QUERY")]
@@ -894,6 +931,7 @@ pub struct EnrichArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `smallweb` feed subcommand.
 pub struct SmallWebArgs {
     /// Limit number of feed entries returned by the Small Web feed
     #[arg(long, value_name = "COUNT")]
@@ -901,12 +939,14 @@ pub struct SmallWebArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `lens` command group.
 pub struct LensCommand {
     #[command(subcommand)]
     pub command: LensSubcommand,
 }
 
 #[derive(Debug, Subcommand)]
+/// Subcommands for lens management.
 pub enum LensSubcommand {
     /// List available lenses and whether they are enabled
     List,
@@ -925,6 +965,7 @@ pub enum LensSubcommand {
 }
 
 #[derive(Debug, Args)]
+/// Arguments targeting a specific lens.
 pub struct LensTargetArgs {
     /// Lens id or exact lens name
     #[arg(value_name = "ID_OR_NAME")]
@@ -932,6 +973,7 @@ pub struct LensTargetArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for creating a new lens.
 pub struct LensCreateArgs {
     /// Lens display name
     #[arg(value_name = "NAME")]
@@ -990,6 +1032,7 @@ pub struct LensCreateArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for updating an existing lens.
 pub struct LensUpdateArgs {
     /// Lens id or exact lens name
     #[arg(value_name = "ID_OR_NAME")]
@@ -1051,24 +1094,28 @@ pub struct LensUpdateArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `bang` command group.
 pub struct BangCommand {
     #[command(subcommand)]
     pub command: BangSubcommand,
 }
 
 #[derive(Debug, Subcommand)]
+/// Subcommands for bang shortcuts.
 pub enum BangSubcommand {
     /// Manage custom bangs
     Custom(CustomBangCommand),
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `bang custom` command group.
 pub struct CustomBangCommand {
     #[command(subcommand)]
     pub command: CustomBangSubcommand,
 }
 
 #[derive(Debug, Subcommand)]
+/// Subcommands for custom bang management.
 pub enum CustomBangSubcommand {
     /// List custom bangs
     List,
@@ -1083,6 +1130,7 @@ pub enum CustomBangSubcommand {
 }
 
 #[derive(Debug, Args)]
+/// Arguments targeting a specific custom bang.
 pub struct CustomBangTargetArgs {
     /// Bang id, exact name, or trigger (with or without leading '!')
     #[arg(value_name = "ID_OR_NAME")]
@@ -1090,6 +1138,7 @@ pub struct CustomBangTargetArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for creating a new custom bang.
 pub struct CustomBangCreateArgs {
     /// Bang display name
     #[arg(value_name = "NAME")]
@@ -1140,6 +1189,7 @@ pub struct CustomBangCreateArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for updating an existing custom bang.
 pub struct CustomBangUpdateArgs {
     /// Bang id, exact name, or trigger (with or without leading '!')
     #[arg(value_name = "ID_OR_NAME")]
@@ -1192,12 +1242,14 @@ pub struct CustomBangUpdateArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for the `redirect` command group.
 pub struct RedirectCommand {
     #[command(subcommand)]
     pub command: RedirectSubcommand,
 }
 
 #[derive(Debug, Subcommand)]
+/// Subcommands for redirect rule management.
 pub enum RedirectSubcommand {
     /// List redirect rules
     List,
@@ -1216,6 +1268,7 @@ pub enum RedirectSubcommand {
 }
 
 #[derive(Debug, Args)]
+/// Arguments targeting a specific redirect rule.
 pub struct RedirectTargetArgs {
     /// Redirect id or exact rule text
     #[arg(value_name = "ID_OR_RULE")]
@@ -1223,6 +1276,7 @@ pub struct RedirectTargetArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for creating a new redirect rule.
 pub struct RedirectCreateArgs {
     /// Full regex|replacement rule
     #[arg(value_name = "RULE")]
@@ -1230,6 +1284,7 @@ pub struct RedirectCreateArgs {
 }
 
 #[derive(Debug, Args)]
+/// Arguments for updating an existing redirect rule.
 pub struct RedirectUpdateArgs {
     /// Redirect id or exact rule text
     #[arg(value_name = "ID_OR_RULE")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 /// upstream errors (e.g. `serde_json::Error`) into the appropriate variant
 /// using the provided `From` implementations.
 #[derive(Debug, Error)]
+/// Top-level error type for kagi-cli operations.
 pub enum KagiError {
     /// A network-related failure (connection, timeout, DNS, HTTP status).
     #[error("network error: {0}")]

--- a/src/search.rs
+++ b/src/search.rs
@@ -23,6 +23,7 @@ const UNAUTHENTICATED_MARKERS: [&str; 3] = [
 ];
 
 #[derive(Debug, Clone)]
+/// Parameters for a Kagi search API request.
 pub struct SearchRequest {
     pub query: String,
     pub lens: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -556,6 +556,7 @@ pub struct LensDetails {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request body for creating a new Kagi lens.
 pub struct LensCreateRequest {
     pub name: String,
     pub included_sites: Option<String>,
@@ -575,6 +576,7 @@ pub struct LensCreateRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request body for updating an existing Kagi lens.
 pub struct LensUpdateRequest {
     pub target: String,
     pub name: Option<String>,
@@ -595,6 +597,7 @@ pub struct LensUpdateRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Summary view of a custom bang shortcut.
 pub struct CustomBangSummary {
     pub id: String,
     pub name: String,
@@ -604,6 +607,7 @@ pub struct CustomBangSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Detailed view of a custom bang shortcut.
 pub struct CustomBangDetails {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bang_id: Option<String>,
@@ -620,6 +624,7 @@ pub struct CustomBangDetails {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request body for creating a new custom bang.
 pub struct CustomBangCreateRequest {
     pub name: String,
     pub trigger: String,
@@ -634,6 +639,7 @@ pub struct CustomBangCreateRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request body for updating an existing custom bang.
 pub struct CustomBangUpdateRequest {
     pub target: String,
     pub name: Option<String>,
@@ -649,6 +655,7 @@ pub struct CustomBangUpdateRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Summary view of a URL redirect rule.
 pub struct RedirectRuleSummary {
     pub id: String,
     pub rule: String,
@@ -657,6 +664,7 @@ pub struct RedirectRuleSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Detailed view of a URL redirect rule.
 pub struct RedirectRuleDetails {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rule_id: Option<String>,
@@ -666,28 +674,33 @@ pub struct RedirectRuleDetails {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request body for creating a new redirect rule.
 pub struct RedirectRuleCreateRequest {
     pub rule: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request body for updating an existing redirect rule.
 pub struct RedirectRuleUpdateRequest {
     pub target: String,
     pub rule: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response confirming resource deletion.
 pub struct DeletedResourceResponse {
     pub id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response confirming a resource state toggle.
 pub struct ToggleResourceResponse {
     pub id: String,
     pub enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Request body for the FastGPT quick-answer endpoint.
 pub struct FastGptRequest {
     pub query: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -697,6 +710,7 @@ pub struct FastGptRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A web reference cited in a FastGPT answer.
 pub struct Reference {
     pub title: String,
     pub snippet: String,
@@ -704,6 +718,7 @@ pub struct Reference {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A single FastGPT answer with references.
 pub struct FastGptAnswer {
     pub output: String,
     pub tokens: u64,
@@ -712,23 +727,27 @@ pub struct FastGptAnswer {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response from the FastGPT endpoint.
 pub struct FastGptResponse {
     pub meta: ApiMeta,
     pub data: FastGptAnswer,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response from the web/news enrichment endpoint.
 pub struct EnrichResponse {
     pub meta: ApiMeta,
     pub data: Vec<SearchResult>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A single entry from the Small Web feed.
 pub struct SmallWebFeed {
     pub xml: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+/// Metadata for a quick-answer response.
 pub struct QuickMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
@@ -737,6 +756,7 @@ pub struct QuickMeta {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A message in a quick-answer conversation.
 pub struct QuickMessage {
     pub id: String,
     pub thread_id: String,
@@ -748,6 +768,7 @@ pub struct QuickMessage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A single reference item in a quick answer.
 pub struct QuickReferenceItem {
     pub index: usize,
     pub title: String,
@@ -759,6 +780,7 @@ pub struct QuickReferenceItem {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+/// Collection of reference items for a quick answer.
 pub struct QuickReferenceCollection {
     #[serde(default)]
     pub markdown: String,
@@ -767,6 +789,7 @@ pub struct QuickReferenceCollection {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response from the quick-answer endpoint.
 pub struct QuickResponse {
     pub meta: QuickMeta,
     pub query: String,
@@ -779,6 +802,7 @@ pub struct QuickResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Request body for the translate endpoint.
 pub struct TranslateCommandRequest {
     pub text: String,
     pub from: String,
@@ -806,6 +830,7 @@ pub struct TranslateCommandRequest {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+/// State of a translation option (enabled/disabled).
 pub struct TranslateOptionState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub formality: Option<String>,
@@ -822,18 +847,21 @@ pub struct TranslateOptionState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Bootstrap metadata for translation initialization.
 pub struct TranslateBootstrapMetadata {
     pub method: String,
     pub authenticated: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A warning returned during translation.
 pub struct TranslateWarning {
     pub section: String,
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// An alternative detected language candidate.
 pub struct TranslateDetectedLanguageAlternative {
     pub iso: String,
     pub label: String,
@@ -844,6 +872,7 @@ pub struct TranslateDetectedLanguageAlternative {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Detected source language with confidence info.
 pub struct TranslateDetectedLanguage {
     pub iso: String,
     pub label: String,
@@ -856,6 +885,7 @@ pub struct TranslateDetectedLanguage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response containing the translated text.
 pub struct TranslateTextResponse {
     pub translation: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -869,6 +899,7 @@ pub struct TranslateTextResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A single alternative translation variant.
 pub struct AlternativeTranslationElement {
     pub translation: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -876,6 +907,7 @@ pub struct AlternativeTranslationElement {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response containing alternative translations.
 pub struct AlternativeTranslationsResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub original_description: Option<String>,
@@ -884,6 +916,7 @@ pub struct AlternativeTranslationsResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response containing word-level alignment data.
 pub struct TextAlignmentsResponse {
     #[serde(default)]
     pub source_blocks: Vec<Value>,
@@ -898,6 +931,7 @@ pub struct TextAlignmentsResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A translation suggestion for a word or phrase.
 pub struct TranslationSuggestion {
     pub id: String,
     pub label: String,
@@ -913,12 +947,14 @@ pub struct TranslationSuggestion {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// Response containing translation suggestions.
 pub struct TranslationSuggestionsResponse {
     #[serde(default)]
     pub suggestions: Vec<TranslationSuggestion>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A variation of a word insight entry.
 pub struct WordInsightVariation {
     pub text: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -926,6 +962,7 @@ pub struct WordInsightVariation {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Detailed insight about a translated word.
 pub struct WordInsight {
     pub id: String,
     pub original_text: String,
@@ -935,6 +972,7 @@ pub struct WordInsight {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Response containing word insights.
 pub struct WordInsightsResponse {
     #[serde(default)]
     pub insights: Vec<WordInsight>,
@@ -943,6 +981,7 @@ pub struct WordInsightsResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// Full response from the translate endpoint.
 pub struct TranslateResponse {
     pub bootstrap: TranslateBootstrapMetadata,
     pub detected_language: TranslateDetectedLanguage,


### PR DESCRIPTION
## Nightshift: docs-backfill

Adds `///` doc comments to all 106 undocumented public types across the crate.

### Changes

| File | Items Documented |
|------|-----------------|
| `api.rs` | `NewsFilterRequest`, `KagiEnvelope` |
| `auth.rs` | `CredentialKind`, `CredentialSource`, `SearchAuthPreference`, `Credential`, `SearchCredentials`, `SearchAuthRequirement`, `CredentialInventory`, `ConfigAuthSnapshot` |
| `cli.rs` | 55 CLI argument structs, enums, and subcommand types |
| `error.rs` | `KagiError` |
| `search.rs` | `SearchRequest` |
| `types.rs` | 39 API request/response types (lens, bang, redirect, fastgpt, translate) |

### Verification
- `cargo check` passes clean
- No functional changes — documentation only
- All comments describe the purpose of each type

---
*Autonomous PR by [nightshift](https://github.com/nightshift-micr) • Task: `docs-backfill` • Tier: low*