### PR TITLE
fix: clear actionable kagi-cli backlog

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: coverage-lcov
           path: lcov.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload packaged assets (unix)
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: release-${{ matrix.target }}
           path: |
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload packaged assets (windows)
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: release-${{ matrix.target }}
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
@@ -1947,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1971,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
-clap_complete = "4.6.0"
+clap_complete = "4.6.2"
 cliclack = "0.5.4"
 console = "0.16.3"
 ctrlc = "3.5.2"
@@ -34,7 +34,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
 tokio = { version = "1.51.1", features = ["macros", "rt-multi-thread"] }
-toml = "1.1.1"
+toml = "1.1.2"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -500,13 +500,7 @@ fn save_credentials_with_preference_to_path(
             config_path.display()
         ))
     })?;
-    fs::write(config_path, raw).map_err(|error| {
-        KagiError::Config(format!(
-            "failed to write config file {}: {error}",
-            config_path.display()
-        ))
-    })?;
-    secure_config_permissions(config_path)?;
+    write_config_file_atomically(config_path, &raw)?;
 
     load_credential_inventory_from_path(config_path)
 }
@@ -581,6 +575,37 @@ fn read_config_file(path: &Path) -> Result<ConfigFile, KagiError> {
             path.display()
         ))
     })
+}
+
+fn write_config_file_atomically(path: &Path, raw: &str) -> Result<(), KagiError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "kagi-config".to_string());
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let temp_path = parent.join(format!(".{file_name}.tmp-{}-{nonce}", std::process::id()));
+
+    fs::write(&temp_path, raw).map_err(|error| {
+        KagiError::Config(format!(
+            "failed to write temporary config file {}: {error}",
+            temp_path.display()
+        ))
+    })?;
+    secure_config_permissions(&temp_path)?;
+
+    if let Err(error) = fs::rename(&temp_path, path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(KagiError::Config(format!(
+            "failed to replace config file {}: {error}",
+            path.display()
+        )));
+    }
+
+    secure_config_permissions(path)
 }
 
 #[cfg(unix)]

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,8 +19,8 @@ pub const KAGI_BASE_URL_ENV: &str = "KAGI_BASE_URL";
 pub const KAGI_NEWS_BASE_URL_ENV: &str = "KAGI_NEWS_BASE_URL";
 pub const KAGI_TRANSLATE_BASE_URL_ENV: &str = "KAGI_TRANSLATE_BASE_URL";
 
-static CLIENT_20S: OnceLock<Result<Client, String>> = OnceLock::new();
-static CLIENT_30S: OnceLock<Result<Client, String>> = OnceLock::new();
+static CLIENT_20S: OnceLock<Client> = OnceLock::new();
+static CLIENT_30S: OnceLock<Client> = OnceLock::new();
 
 /// Returns a shared HTTP client with a 20-second timeout.
 ///
@@ -57,20 +57,20 @@ pub fn map_transport_error(error: reqwest::Error) -> KagiError {
     KagiError::Network(format!("request to Kagi failed: {error}"))
 }
 
-/// Reads the response body text, returning an empty string on failure.
+/// Reads the response body text, returning a diagnostic placeholder on failure.
 ///
 /// # Arguments
 /// * `response` - The HTTP response to consume.
 /// * `surface` - A label used in debug logging on read failure.
 ///
 /// # Returns
-/// The response body as a string, or an empty string if the body could not be read.
+/// The response body as a string, or a diagnostic placeholder if the body could not be read.
 pub async fn read_error_body(response: Response, surface: &str) -> String {
     match response.text().await {
         Ok(body) => body,
         Err(error) => {
             debug!(surface, error = %error, "failed to read error response body");
-            String::new()
+            format!("<failed to read error body: {error}>")
         }
     }
 }
@@ -117,22 +117,19 @@ pub fn kagi_translate_url(path: &str) -> String {
     )
 }
 
-fn cached_client(
-    slot: &OnceLock<Result<Client, String>>,
-    timeout: Duration,
-) -> Result<Client, KagiError> {
-    let result = slot.get_or_init(|| {
-        Client::builder()
-            .user_agent(USER_AGENT)
-            .timeout(timeout)
-            .build()
-            .map_err(|error| format!("failed to build HTTP client: {error}"))
-    });
+fn cached_client(slot: &OnceLock<Client>, timeout: Duration) -> Result<Client, KagiError> {
+    if let Some(client) = slot.get() {
+        return Ok(client.clone());
+    }
 
-    result
-        .as_ref()
-        .cloned()
-        .map_err(|error| KagiError::Network(error.clone()))
+    let client = Client::builder()
+        .user_agent(USER_AGENT)
+        .timeout(timeout)
+        .build()
+        .map_err(|error| KagiError::Network(format!("failed to build HTTP client: {error}")))?;
+
+    let _ = slot.set(client.clone());
+    Ok(client)
 }
 
 fn base_url_from_env(key: &str, default: &str) -> String {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -489,7 +489,9 @@ pub fn parse_redirect_list(html: &str) -> Result<Vec<RedirectRuleSummary>, KagiE
             continue;
         }
 
-        let edit_url = edit_url.unwrap().to_string();
+        let edit_url = edit_url
+            .ok_or_else(|| KagiError::Parse("redirect row missing edit URL".to_string()))?
+            .to_string();
         let id = parse_query_value(&edit_url, "rule_id")
             .or_else(|| toggle_form.and_then(|form| extract_input_value_from(&form, "rule_id")))
             .ok_or_else(|| KagiError::Parse("redirect row missing rule_id".to_string()))?;


### PR DESCRIPTION
**Summary**
- refresh the remaining backlog dependency bumps by updating `clap_complete` to `4.6.2`, `toml` to `1.1.2`, and the stale `actions/upload-artifact` workflow pins to `v7.0.1`
- stop permanently caching failed HTTP client initialization so transient client-build failures do not poison the process
- write `.kagi.toml` atomically while preserving hardened file permissions
- remove the production redirect-parser `unwrap()` and keep unreadable error bodies diagnostic instead of silently empty

**Verification**
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`