### PR TITLE
fix: paginate assistant thread list results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- `kagi assistant thread list` now follows Kagi's pagination cursor so large Assistant histories return beyond the first 100 threads, and thread-list parsing now tolerates object-shaped cursors plus nullable `total_counts`
+
 ## [0.4.5]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ kagi assistant thread list
 kagi assistant thread export <THREAD_ID>
 ```
 
+`kagi assistant thread list` automatically follows Kagi's pagination cursor so large chat histories are returned in one response.
+
 manage custom assistants:
 
 ```bash

--- a/src/api.rs
+++ b/src/api.rs
@@ -509,6 +509,7 @@ pub async fn execute_assistant_thread_list(
     let mut last_response;
     let mut all_threads = Vec::new();
     let mut cursor = None;
+    let mut merged_total_counts = HashMap::new();
 
     loop {
         let mut payload = Map::new();
@@ -531,6 +532,11 @@ pub async fn execute_assistant_thread_list(
             .next_cursor
             .as_deref()
             .and_then(parse_assistant_thread_cursor);
+        // Preserve any non-null totals seen on earlier pages because later pages
+        // can omit `total_counts` entirely while still returning more threads.
+        for (key, value) in &response.pagination.total_counts {
+            merged_total_counts.entry(key.clone()).or_insert(*value);
+        }
         all_threads.append(&mut response.threads);
 
         let has_more = response.pagination.has_more;
@@ -542,6 +548,9 @@ pub async fn execute_assistant_thread_list(
 
     let mut response = last_response;
     response.threads = all_threads;
+    for (key, value) in merged_total_counts {
+        response.pagination.total_counts.entry(key).or_insert(value);
+    }
     response.pagination.count = response.threads.len() as u64;
     Ok(response)
 }
@@ -4686,7 +4695,7 @@ mod tests {
                 .body(concat!(
                     "hi:{\"v\":\"test\",\"trace\":\"trace-list\"}\0\n",
                     "tags.json:[]\0\n",
-                    "thread_list.html:{\"html\":\"<div class=\\\"hide-if-no-threads\\\"><ul class=\\\"thread-list\\\"><li class=\\\"thread\\\" data-code=\\\"thread-2\\\" data-saved=\\\"false\\\" data-public=\\\"false\\\" data-tags='[]' data-snippet=\\\"Second snippet\\\"><a href=\\\"/assistant/thread-2\\\"><div class=\\\"title\\\">Second Thread</div><div class=\\\"excerpt\\\">Second snippet</div></a></li></ul></div>\",\"next_cursor\":null,\"has_more\":false,\"count\":1,\"total_counts\":{\"all\":2}}\0\n"
+                    "thread_list.html:{\"html\":\"<div class=\\\"hide-if-no-threads\\\"><ul class=\\\"thread-list\\\"><li class=\\\"thread\\\" data-code=\\\"thread-2\\\" data-saved=\\\"false\\\" data-public=\\\"false\\\" data-tags='[]' data-snippet=\\\"Second snippet\\\"><a href=\\\"/assistant/thread-2\\\"><div class=\\\"title\\\">Second Thread</div><div class=\\\"excerpt\\\">Second snippet</div></a></li></ul></div>\",\"next_cursor\":null,\"has_more\":false,\"count\":1,\"total_counts\":null}\0\n"
                 ));
         });
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -3365,17 +3365,17 @@ fn parse_assistant_thread_delete_stream(
 }
 
 fn assistant_thread_list_html(payload: &Value) -> Result<&str, KagiError> {
-    let html = payload
-        .get("html")
-        .ok_or_else(|| KagiError::Parse("assistant thread list payload missing html".to_string()))?;
+    let html = payload.get("html").ok_or_else(|| {
+        KagiError::Parse("assistant thread list payload missing html".to_string())
+    })?;
 
     if let Some(html) = html.as_str() {
         return Ok(html);
     }
 
-    html.get("html")
-        .and_then(Value::as_str)
-        .ok_or_else(|| KagiError::Parse("assistant thread list payload missing html string".to_string()))
+    html.get("html").and_then(Value::as_str).ok_or_else(|| {
+        KagiError::Parse("assistant thread list payload missing html string".to_string())
+    })
 }
 
 fn assistant_thread_list_next_cursor(payload: &Value) -> Option<String> {
@@ -4166,14 +4166,13 @@ mod tests {
         fake_header_map, finalize_translate_text_response, normalize_ask_page_question,
         normalize_ask_page_url, normalize_assistant_query, normalize_assistant_thread_id,
         normalize_aux_quality, normalize_custom_bang_trigger, normalize_redirect_rule,
-        parse_assistant_thread_cursor,
         normalize_subscriber_summary_input, normalize_subscriber_summary_length,
         normalize_subscriber_summary_type, parse_assistant_prompt_stream,
-        parse_assistant_thread_delete_stream, parse_assistant_thread_list_stream,
-        parse_assistant_thread_open_stream, parse_content_disposition_filename,
-        parse_subscriber_summarize_stream, parse_translate_detect_value,
-        resolve_custom_assistant_ref, resolve_custom_bang_ref, resolve_lens_ref,
-        resolve_news_category, resolve_redirect_ref, resolve_translate_bootstrap,
+        parse_assistant_thread_cursor, parse_assistant_thread_delete_stream,
+        parse_assistant_thread_list_stream, parse_assistant_thread_open_stream,
+        parse_content_disposition_filename, parse_subscriber_summarize_stream,
+        parse_translate_detect_value, resolve_custom_assistant_ref, resolve_custom_bang_ref,
+        resolve_lens_ref, resolve_news_category, resolve_redirect_ref, resolve_translate_bootstrap,
         should_retry_translate_bootstrap, text_contains_news_filter_keyword,
         validate_translate_request,
     };
@@ -4206,15 +4205,34 @@ mod tests {
         Arc,
         atomic::{AtomicBool, Ordering},
     };
-
-    fn set_env_var(key: &str, value: &str) {
-        unsafe { std::env::set_var(key, value) }
-    }
-
-    fn remove_env_var(key: &str) {
-        unsafe { std::env::remove_var(key) }
-    }
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) }
+
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            match self.previous.as_deref() {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    fn set_env_var(key: &'static str, value: &str) -> ScopedEnvVar {
+        ScopedEnvVar::set(key, value)
+    }
 
     fn sample_translate_request() -> TranslateCommandRequest {
         TranslateCommandRequest {
@@ -4672,11 +4690,10 @@ mod tests {
                 ));
         });
 
-        set_env_var("KAGI_BASE_URL", &server.base_url());
+        let _base_url_env = set_env_var("KAGI_BASE_URL", &server.base_url());
         let response = execute_assistant_thread_list("test-session")
             .await
             .expect("thread list should succeed");
-        remove_env_var("KAGI_BASE_URL");
 
         assert_eq!(response.meta.trace.as_deref(), Some("trace-list"));
         assert_eq!(response.threads.len(), 2);

--- a/src/api.rs
+++ b/src/api.rs
@@ -144,6 +144,7 @@ pub async fn execute_summarize(
 /// 
 /// # Arguments
 /// * `request` - The subscriber summarize request.
+/// * `list_id` - Optional thread or tag id used to continue listing.
 /// * `token` - The Kagi session token.
 /// 
 /// # Returns
@@ -506,15 +507,44 @@ pub async fn execute_assistant_prompt(
 pub async fn execute_assistant_thread_list(
     token: &str,
 ) -> Result<AssistantThreadListResponse, KagiError> {
-    let body = execute_assistant_stream(
-        &http::kagi_url(KAGI_ASSISTANT_THREAD_LIST_PATH),
-        &json!({ "limit": 100 }),
-        token,
-        "Assistant thread list",
-    )
-    .await?;
+    let mut last_response;
+    let mut all_threads = Vec::new();
+    let mut cursor = None;
 
-    parse_assistant_thread_list_stream(&body)
+    loop {
+        let mut payload = Map::new();
+        if let Some(cursor_value) = cursor.clone() {
+            payload.insert(String::from("cursor"), cursor_value);
+        }
+        payload.insert(String::from("limit"), json!(100));
+
+        let body = execute_assistant_stream(
+            &http::kagi_url(KAGI_ASSISTANT_THREAD_LIST_PATH),
+            &Value::Object(payload),
+            token,
+            "Assistant thread list",
+        )
+        .await?;
+
+        let mut response = parse_assistant_thread_list_stream(&body)?;
+        cursor = response
+            .pagination
+            .next_cursor
+            .as_deref()
+            .and_then(parse_assistant_thread_cursor);
+        all_threads.append(&mut response.threads);
+
+        let has_more = response.pagination.has_more;
+        last_response = response;
+        if !has_more || cursor.is_none() {
+            break;
+        }
+    }
+
+    let mut response = last_response;
+    response.threads = all_threads;
+    response.pagination.count = response.threads.len() as u64;
+    Ok(response)
 }
 
 /// Opens a specific Kagi Assistant thread and returns its messages.
@@ -3235,18 +3265,21 @@ fn parse_assistant_thread_list_stream(
                 })?;
             }
             "thread_list.html" => {
-                let payload: AssistantThreadListPayload =
-                    serde_json::from_str(payload).map_err(|error| {
-                        KagiError::Parse(format!(
-                            "failed to parse assistant thread list frame: {error}"
-                        ))
-                    })?;
-                threads = parse_assistant_thread_list(payload.html.as_str())?;
+                let payload: Value = serde_json::from_str(payload).map_err(|error| {
+                    KagiError::Parse(format!(
+                        "failed to parse assistant thread list frame: {error}"
+                    ))
+                })?;
+                let html = assistant_thread_list_html(&payload)?;
+                threads = parse_assistant_thread_list(html)?;
                 pagination = Some(AssistantThreadPagination {
-                    next_cursor: payload.next_cursor.into_opaque_string(),
-                    has_more: payload.has_more,
-                    count: payload.count,
-                    total_counts: payload.total_counts,
+                    next_cursor: assistant_thread_list_next_cursor(&payload),
+                    has_more: payload
+                        .get("has_more")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                    count: payload.get("count").and_then(Value::as_u64).unwrap_or(0),
+                    total_counts: assistant_thread_list_total_counts(&payload),
                 });
             }
             "limit_notice.html" => {
@@ -3323,6 +3356,49 @@ fn parse_assistant_thread_delete_stream(
     Err(KagiError::Parse(
         "assistant thread delete response did not include an ok frame".to_string(),
     ))
+}
+
+fn assistant_thread_list_html(payload: &Value) -> Result<&str, KagiError> {
+    let html = payload
+        .get("html")
+        .ok_or_else(|| KagiError::Parse("assistant thread list payload missing html".to_string()))?;
+
+    if let Some(html) = html.as_str() {
+        return Ok(html);
+    }
+
+    html.get("html")
+        .and_then(Value::as_str)
+        .ok_or_else(|| KagiError::Parse("assistant thread list payload missing html string".to_string()))
+}
+
+fn assistant_thread_list_next_cursor(payload: &Value) -> Option<String> {
+    payload.get("next_cursor").and_then(|cursor| {
+        if cursor.is_null() {
+            None
+        } else {
+            Some(cursor.to_string())
+        }
+    })
+}
+
+fn assistant_thread_list_total_counts(payload: &Value) -> HashMap<String, u64> {
+    payload
+        .get("total_counts")
+        .and_then(Value::as_object)
+        .map(|counts| {
+            counts
+                .iter()
+                .filter_map(|(key, value)| value.as_u64().map(|value| (key.clone(), value)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_assistant_thread_cursor(cursor: &str) -> Option<Value> {
+    serde_json::from_str::<Value>(cursor)
+        .ok()
+        .or_else(|| Some(json!({ "id": cursor })))
 }
 
 fn assistant_message_from_payload(payload: AssistantMessagePayload) -> AssistantMessage {
@@ -3866,54 +3942,6 @@ struct AssistantMessagePayload {
     trace_id: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-struct AssistantThreadListPayload {
-    html: AssistantThreadListHtml,
-    #[serde(default)]
-    next_cursor: AssistantThreadListCursor,
-    #[serde(default)]
-    has_more: bool,
-    #[serde(default)]
-    count: u64,
-    #[serde(default)]
-    total_counts: HashMap<String, u64>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum AssistantThreadListHtml {
-    Raw(String),
-    Wrapped { html: String },
-}
-
-impl AssistantThreadListHtml {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Raw(html) => html,
-            Self::Wrapped { html } => html,
-        }
-    }
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(untagged)]
-enum AssistantThreadListCursor {
-    String(String),
-    Opaque(Value),
-    #[default]
-    Missing,
-}
-
-impl AssistantThreadListCursor {
-    fn into_opaque_string(self) -> Option<String> {
-        match self {
-            Self::String(value) => Some(value),
-            Self::Opaque(value) => Some(value.to_string()),
-            Self::Missing => None,
-        }
-    }
-}
-
 #[derive(Debug)]
 struct TranslateBootstrapResult {
     translate_session: String,
@@ -4113,6 +4141,7 @@ mod tests {
         fake_header_map, finalize_translate_text_response, normalize_ask_page_question,
         normalize_ask_page_url, normalize_assistant_query, normalize_assistant_thread_id,
         normalize_aux_quality, normalize_custom_bang_trigger, normalize_redirect_rule,
+        parse_assistant_thread_cursor,
         normalize_subscriber_summary_input, normalize_subscriber_summary_length,
         normalize_subscriber_summary_type, parse_assistant_prompt_stream,
         parse_assistant_thread_delete_stream, parse_assistant_thread_list_stream,
@@ -4152,6 +4181,14 @@ mod tests {
         Arc,
         atomic::{AtomicBool, Ordering},
     };
+
+    fn set_env_var(key: &str, value: &str) {
+        unsafe { std::env::set_var(key, value) }
+    }
+
+    fn remove_env_var(key: &str) {
+        unsafe { std::env::remove_var(key) }
+    }
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn sample_translate_request() -> TranslateCommandRequest {
@@ -4546,6 +4583,82 @@ mod tests {
             vec!["00000000-0000-4000-0000-000000000000".to_string()]
         );
         assert_eq!(parsed.message.trace_id.as_deref(), Some("trace-message-1"));
+    }
+
+    #[test]
+    fn parses_assistant_thread_cursor_from_cursor_payload() {
+        assert_eq!(
+            parse_assistant_thread_cursor(
+                r#"{"ack":"2026-02-11T16:22:13Z","created_at":"2026-02-11T16:22:13Z","id":"cursor-123"}"#
+            ),
+            Some(json!({
+                "ack": "2026-02-11T16:22:13Z",
+                "created_at": "2026-02-11T16:22:13Z",
+                "id": "cursor-123"
+            }))
+        );
+        assert_eq!(
+            parse_assistant_thread_cursor("cursor-123"),
+            Some(json!({ "id": "cursor-123" }))
+        );
+    }
+
+    #[tokio::test]
+    async fn assistant_thread_list_follows_cursor_pagination() {
+        use httpmock::Method::POST;
+        use httpmock::MockServer;
+
+        let server = MockServer::start();
+        let _first_page = server.mock(|when, then| {
+            when.method(POST)
+                .path("/assistant/thread_list")
+                .header("cookie", "kagi_session=test-session")
+                .header("accept", "application/vnd.kagi.stream")
+                .header("content-type", "application/json")
+                .json_body(json!({ "limit": 100 }));
+            then.status(200)
+                .header("content-type", "application/vnd.kagi.stream")
+                .body(concat!(
+                    "hi:{\"v\":\"test\",\"trace\":\"trace-list\"}\0\n",
+                    "tags.json:[]\0\n",
+                    "thread_list.html:{\"html\":\"<div class=\\\"hide-if-no-threads\\\"><ul class=\\\"thread-list\\\"><li class=\\\"thread\\\" data-code=\\\"thread-1\\\" data-saved=\\\"false\\\" data-public=\\\"false\\\" data-tags='[]' data-snippet=\\\"First snippet\\\"><a href=\\\"/assistant/thread-1\\\"><div class=\\\"title\\\">First Thread</div><div class=\\\"excerpt\\\">First snippet</div></a></li></ul></div>\",\"next_cursor\":{\"ack\":\"2026-02-11T16:22:13Z\",\"created_at\":\"2026-02-11T16:22:13Z\",\"id\":\"cursor-123\"},\"has_more\":true,\"count\":1,\"total_counts\":{\"all\":2}}\0\n"
+                ));
+        });
+        let _second_page = server.mock(|when, then| {
+            when.method(POST)
+                .path("/assistant/thread_list")
+                .header("cookie", "kagi_session=test-session")
+                .header("accept", "application/vnd.kagi.stream")
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "limit": 100,
+                    "cursor": {
+                        "ack": "2026-02-11T16:22:13Z",
+                        "created_at": "2026-02-11T16:22:13Z",
+                        "id": "cursor-123"
+                    }
+                }));
+            then.status(200)
+                .header("content-type", "application/vnd.kagi.stream")
+                .body(concat!(
+                    "hi:{\"v\":\"test\",\"trace\":\"trace-list\"}\0\n",
+                    "tags.json:[]\0\n",
+                    "thread_list.html:{\"html\":\"<div class=\\\"hide-if-no-threads\\\"><ul class=\\\"thread-list\\\"><li class=\\\"thread\\\" data-code=\\\"thread-2\\\" data-saved=\\\"false\\\" data-public=\\\"false\\\" data-tags='[]' data-snippet=\\\"Second snippet\\\"><a href=\\\"/assistant/thread-2\\\"><div class=\\\"title\\\">Second Thread</div><div class=\\\"excerpt\\\">Second snippet</div></a></li></ul></div>\",\"next_cursor\":null,\"has_more\":false,\"count\":1,\"total_counts\":{\"all\":2}}\0\n"
+                ));
+        });
+
+        set_env_var("KAGI_BASE_URL", &server.base_url());
+        let response = execute_assistant_thread_list("test-session")
+            .await
+            .expect("thread list should succeed");
+        remove_env_var("KAGI_BASE_URL");
+
+        assert_eq!(response.meta.trace.as_deref(), Some("trace-list"));
+        assert_eq!(response.threads.len(), 2);
+        assert_eq!(response.threads[0].id, "thread-1");
+        assert_eq!(response.threads[1].id, "thread-2");
+        assert_eq!(response.pagination.count, 2);
+        assert_eq!(response.pagination.total_counts.get("all"), Some(&2));
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -3241,9 +3241,9 @@ fn parse_assistant_thread_list_stream(
                             "failed to parse assistant thread list frame: {error}"
                         ))
                     })?;
-                threads = parse_assistant_thread_list(&payload.html)?;
+                threads = parse_assistant_thread_list(payload.html.as_str())?;
                 pagination = Some(AssistantThreadPagination {
-                    next_cursor: payload.next_cursor,
+                    next_cursor: payload.next_cursor.into_opaque_string(),
                     has_more: payload.has_more,
                     count: payload.count,
                     total_counts: payload.total_counts,
@@ -3868,15 +3868,50 @@ struct AssistantMessagePayload {
 
 #[derive(Debug, Deserialize)]
 struct AssistantThreadListPayload {
-    html: String,
+    html: AssistantThreadListHtml,
     #[serde(default)]
-    next_cursor: Option<String>,
+    next_cursor: AssistantThreadListCursor,
     #[serde(default)]
     has_more: bool,
     #[serde(default)]
     count: u64,
     #[serde(default)]
     total_counts: HashMap<String, u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum AssistantThreadListHtml {
+    Raw(String),
+    Wrapped { html: String },
+}
+
+impl AssistantThreadListHtml {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Raw(html) => html,
+            Self::Wrapped { html } => html,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(untagged)]
+enum AssistantThreadListCursor {
+    String(String),
+    Opaque(Value),
+    #[default]
+    Missing,
+}
+
+impl AssistantThreadListCursor {
+    fn into_opaque_string(self) -> Option<String> {
+        match self {
+            Self::String(value) => Some(value),
+            Self::Opaque(value) => Some(value.to_string()),
+            Self::Missing => None,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -4666,6 +4701,32 @@ mod tests {
         assert_eq!(parsed.threads[0].id, "thread-1");
         assert_eq!(parsed.pagination.count, 1);
         assert_eq!(parsed.pagination.total_counts.get("all"), Some(&1));
+    }
+
+    #[test]
+    fn parses_assistant_thread_list_stream_with_wrapped_html_and_object_cursor() {
+        let raw = concat!(
+            "hi:{\"v\":\"202603171911.stage.707e740\",\"trace\":\"trace-list-object\"}\0\n",
+            "tags.json:[]\0\n",
+            "thread_list.html:{\"html\":{\"html\":\"<div class=\\\"hide-if-no-threads\\\"><ul class=\\\"thread-list\\\"><li class=\\\"thread\\\" data-code=\\\"thread-2\\\" data-saved=\\\"false\\\" data-public=\\\"true\\\" data-tags='[]' data-snippet=\\\"Second snippet\\\"><a href=\\\"/assistant/thread-2\\\"><div class=\\\"title\\\">Second Thread</div><div class=\\\"excerpt\\\">Second snippet</div></a></li></ul></div>\"},\"next_cursor\":{\"offset\":100,\"has_more\":true},\"has_more\":true,\"count\":100,\"total_counts\":{\"all\":250}}\0\n"
+        );
+
+        let parsed = parse_assistant_thread_list_stream(raw).expect("thread list parses");
+        assert_eq!(parsed.meta.trace.as_deref(), Some("trace-list-object"));
+        assert_eq!(parsed.threads.len(), 1);
+        assert_eq!(parsed.threads[0].id, "thread-2");
+        let next_cursor = parsed
+            .pagination
+            .next_cursor
+            .as_deref()
+            .expect("wrapped cursor should be preserved");
+        let next_cursor_json: Value =
+            serde_json::from_str(next_cursor).expect("cursor should stay valid JSON");
+        assert_eq!(next_cursor_json["offset"], 100);
+        assert_eq!(next_cursor_json["has_more"], true);
+        assert!(parsed.pagination.has_more);
+        assert_eq!(parsed.pagination.count, 100);
+        assert_eq!(parsed.pagination.total_counts.get("all"), Some(&250));
     }
 
     #[test]

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -465,7 +465,7 @@ fn assistant_thread_list_paginates_with_cursor_id() {
             .body(concat!(
                 "hi:{\"v\":\"test\",\"trace\":\"trace-list\"}\0\n",
                 "tags.json:[]\0\n",
-                "thread_list.html:{\"html\":\"<div class=\\\"hide-if-no-threads\\\"><ul class=\\\"thread-list\\\"><li class=\\\"thread\\\" data-code=\\\"thread-2\\\" data-saved=\\\"false\\\" data-public=\\\"false\\\" data-tags='[]' data-snippet=\\\"Second snippet\\\"><a href=\\\"/assistant/thread-2\\\"><div class=\\\"title\\\">Second Thread</div><div class=\\\"excerpt\\\">Second snippet</div></a></li></ul></div>\",\"next_cursor\":null,\"has_more\":false,\"count\":1,\"total_counts\":{\"all\":2}}\0\n"
+                "thread_list.html:{\"html\":\"<div class=\\\"hide-if-no-threads\\\"><ul class=\\\"thread-list\\\"><li class=\\\"thread\\\" data-code=\\\"thread-2\\\" data-saved=\\\"false\\\" data-public=\\\"false\\\" data-tags='[]' data-snippet=\\\"Second snippet\\\"><a href=\\\"/assistant/thread-2\\\"><div class=\\\"title\\\">Second Thread</div><div class=\\\"excerpt\\\">Second snippet</div></a></li></ul></div>\",\"next_cursor\":null,\"has_more\":false,\"count\":1,\"total_counts\":null}\0\n"
             ));
     });
 
@@ -483,4 +483,5 @@ fn assistant_thread_list_paginates_with_cursor_id() {
     assert_eq!(body["threads"][0]["id"], "thread-1");
     assert_eq!(body["threads"][1]["id"], "thread-2");
     assert_eq!(body["pagination"]["count"], 2);
+    assert_eq!(body["pagination"]["total_counts"]["all"], 2);
 }

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -471,7 +471,11 @@ fn assistant_thread_list_paginates_with_cursor_id() {
 
     let tempdir = TempDir::new().expect("tempdir");
     let env = session_env(&server);
-    let output = run_kagi(&["assistant", "thread", "list"], &env_refs(&env), tempdir.path());
+    let output = run_kagi(
+        &["assistant", "thread", "list"],
+        &env_refs(&env),
+        tempdir.path(),
+    );
 
     assert_success(&output);
     let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -54,6 +54,13 @@ fn env_refs(values: &[(impl AsRef<str>, impl AsRef<str>)]) -> Vec<(&str, &str)> 
         .collect()
 }
 
+fn session_env(server: &MockServer) -> Vec<(&'static str, String)> {
+    vec![
+        ("KAGI_SESSION_TOKEN", "test-session".to_string()),
+        ("KAGI_BASE_URL", server.base_url()),
+    ]
+}
+
 fn api_meta() -> Value {
     json!({
         "id": "req-1",
@@ -419,4 +426,57 @@ fn news_command_resolves_category_and_prints_json() {
     let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
     assert_eq!(body["category"]["category_name"], "Tech");
     assert_eq!(body["stories"][0]["title"], "Rust ships new release");
+}
+
+#[test]
+fn assistant_thread_list_paginates_with_cursor_id() {
+    let server = MockServer::start();
+    let _first_page = server.mock(|when, then| {
+        when.method(POST)
+            .path("/assistant/thread_list")
+            .header("cookie", "kagi_session=test-session")
+            .header("accept", "application/vnd.kagi.stream")
+            .header("content-type", "application/json")
+            .json_body(json!({ "limit": 100 }));
+        then.status(200)
+            .header("content-type", "application/vnd.kagi.stream")
+            .body(concat!(
+                "hi:{\"v\":\"test\",\"trace\":\"trace-list\"}\0\n",
+                "tags.json:[]\0\n",
+                "thread_list.html:{\"html\":\"<div class=\\\"hide-if-no-threads\\\"><ul class=\\\"thread-list\\\"><li class=\\\"thread\\\" data-code=\\\"thread-1\\\" data-saved=\\\"false\\\" data-public=\\\"false\\\" data-tags='[]' data-snippet=\\\"First snippet\\\"><a href=\\\"/assistant/thread-1\\\"><div class=\\\"title\\\">First Thread</div><div class=\\\"excerpt\\\">First snippet</div></a></li></ul></div>\",\"next_cursor\":{\"ack\":\"2026-02-11T16:22:13Z\",\"created_at\":\"2026-02-11T16:22:13Z\",\"id\":\"cursor-123\"},\"has_more\":true,\"count\":1,\"total_counts\":{\"all\":2}}\0\n"
+            ));
+    });
+    let _second_page = server.mock(|when, then| {
+        when.method(POST)
+            .path("/assistant/thread_list")
+            .header("cookie", "kagi_session=test-session")
+            .header("accept", "application/vnd.kagi.stream")
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "limit": 100,
+                "cursor": {
+                    "ack": "2026-02-11T16:22:13Z",
+                    "created_at": "2026-02-11T16:22:13Z",
+                    "id": "cursor-123"
+                }
+            }));
+        then.status(200)
+            .header("content-type", "application/vnd.kagi.stream")
+            .body(concat!(
+                "hi:{\"v\":\"test\",\"trace\":\"trace-list\"}\0\n",
+                "tags.json:[]\0\n",
+                "thread_list.html:{\"html\":\"<div class=\\\"hide-if-no-threads\\\"><ul class=\\\"thread-list\\\"><li class=\\\"thread\\\" data-code=\\\"thread-2\\\" data-saved=\\\"false\\\" data-public=\\\"false\\\" data-tags='[]' data-snippet=\\\"Second snippet\\\"><a href=\\\"/assistant/thread-2\\\"><div class=\\\"title\\\">Second Thread</div><div class=\\\"excerpt\\\">Second snippet</div></a></li></ul></div>\",\"next_cursor\":null,\"has_more\":false,\"count\":1,\"total_counts\":{\"all\":2}}\0\n"
+            ));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = session_env(&server);
+    let output = run_kagi(&["assistant", "thread", "list"], &env_refs(&env), tempdir.path());
+
+    assert_success(&output);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["meta"]["trace"], "trace-list");
+    assert_eq!(body["threads"][0]["id"], "thread-1");
+    assert_eq!(body["threads"][1]["id"], "thread-2");
+    assert_eq!(body["pagination"]["count"], 2);
 }


### PR DESCRIPTION
## Summary
- what changed
  - fixed `kagi assistant thread list` to follow Kagi's pagination cursor and return full thread history instead of stopping at the first 100 results
  - hardened thread-list parsing to tolerate object-shaped `next_cursor`, wrapped `html`, and nullable `total_counts`
  - added API and CLI regression tests for multi-page Assistant thread listing
  - updated README and CHANGELOG for the user-facing behavior change
- why it changed
  - large Assistant histories were truncated at 100 results, and some responses failed to parse with errors like:
    - `parse error: failed to parse assistant thread list frame: invalid type: map, expected a string`
    - `parse error: failed to parse assistant thread list frame: invalid type: null, expected a map`
  - Kagi's thread-list payload shape varies across pages, and the CLI was not replaying the returned pagination cursor
## Verification
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -q`
Live verification count check:
```bash
./target/release/kagi assistant thread list \
  | jq '{listed: (.threads | length), reported_total: (.pagination.total_counts.all // .pagination.count), matches: ((.threads | length) == (.pagination.total_counts.all // .pagination.count))}'
```
## Docs
- [x] README updated if user-facing behavior changed
- [x] CHANGELOG updated for notable user-facing changes
## Auth / Secrets
- [x] No tokens, cookies, or local config secrets were committed
- [x] Any live verification steps are documented without exposing credentials