### PR TITLE
feat: add --limit flag to search and batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Added
+
+- `kagi search` and `kagi batch` accept `--limit <N>` to cap the number of results returned (truncated locally; Kagi's search endpoints have no native count parameter)
+
 ## [0.5.0]
 
 ### Added

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -97,6 +97,9 @@ kagi search --time month --region us --order recency "rust release notes"
 # Date-bounded search
 kagi search --from-date 2026-03-01 --to-date 2026-03-31 "rust release notes"
 
+# Limit results (truncated locally)
+kagi search --limit 5 "rust release notes"
+
 # Per-request personalization override
 kagi search --no-personalized "rust release notes"
 

--- a/docs/commands/batch.mdx
+++ b/docs/commands/batch.mdx
@@ -21,4 +21,5 @@ If no query arguments are provided, `batch` reads one query per stdin line.
 kagi batch "rust" "python" "go" --concurrency 3 --rate-limit 60
 printf 'rust\npython\ngo\n' | kagi batch --format compact
 kagi batch "rust" "zig" --template '{{rank}} {{title}} {{url}}'
+kagi batch "rust" "go" --limit 3
 ```

--- a/docs/commands/search.mdx
+++ b/docs/commands/search.mdx
@@ -200,6 +200,14 @@ kagi search "rust async runtime tradeoffs" --follow 3
 
 `--follow` requires `KAGI_SESSION_TOKEN` because it uses the subscriber summarizer.
 
+### `--limit <N>`
+
+Cap the number of results returned. Truncation happens locally after Kagi's response is received, so `--limit` does not reduce the upstream request cost. Combine with `--follow` to summarize only the top of the capped list.
+
+```bash
+kagi search "rust async runtime tradeoffs" --limit 5
+```
+
 ## Not Supported as Runtime Flags
 
 `safe_search` is currently an account setting, not a search-time flag in this CLI. Configure it in the Kagi web settings instead of expecting `kagi search` to override it per request.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -336,6 +336,23 @@ pub struct SearchArgs {
     /// Summarize the top N result URLs using subscriber summarizer
     #[arg(long, value_name = "N")]
     pub follow: Option<usize>,
+
+    /// Maximum number of search results to return
+    #[arg(long, value_name = "N")]
+    pub limit: Option<usize>,
+}
+
+impl SearchArgs {
+    /// Validates search arguments.
+    ///
+    /// # Errors
+    /// Returns an error if `--limit` is set to zero.
+    pub fn validate(&self) -> Result<(), String> {
+        if matches!(self.limit, Some(0)) {
+            return Err("limit must be at least 1".to_string());
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Args)]
@@ -404,6 +421,10 @@ pub struct BatchSearchArgs {
     /// Render each result with a lightweight template
     #[arg(long, value_name = "TEMPLATE")]
     pub template: Option<String>,
+
+    /// Maximum number of search results to return per query
+    #[arg(long, value_name = "N")]
+    pub limit: Option<usize>,
 }
 
 impl BatchSearchArgs {
@@ -420,6 +441,9 @@ impl BatchSearchArgs {
         }
         if self.queries.is_empty() {
             return Err("batch requires at least one query argument or stdin line".to_string());
+        }
+        if matches!(self.limit, Some(0)) {
+            return Err("limit must be at least 1".to_string());
         }
         Ok(())
     }
@@ -1705,6 +1729,45 @@ mod tests {
                 assert_eq!(args.attach.len(), 2);
                 assert_eq!(args.attach[0].to_string_lossy(), "./a.jpg");
                 assert_eq!(args.attach[1].to_string_lossy(), "./b.pdf");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_search_limit_flag() {
+        let cli = Cli::try_parse_from(["kagi", "search", "rust", "--limit", "5"])
+            .expect("search --limit should parse");
+        match cli.command.expect("command") {
+            Commands::Search(args) => {
+                assert_eq!(args.limit, Some(5));
+                assert!(args.validate().is_ok());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_zero_limit_on_search() {
+        let cli = Cli::try_parse_from(["kagi", "search", "rust", "--limit", "0"])
+            .expect("--limit 0 should parse");
+        match cli.command.expect("command") {
+            Commands::Search(args) => {
+                let error = args.validate().expect_err("zero limit should be rejected");
+                assert!(error.contains("limit must be at least 1"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_zero_limit_on_batch() {
+        let cli = Cli::try_parse_from(["kagi", "batch", "rust", "--limit", "0"])
+            .expect("batch --limit 0 should parse");
+        match cli.command.expect("command") {
+            Commands::Batch(args) => {
+                let error = args.validate().expect_err("zero limit should be rejected");
+                assert!(error.contains("limit must be at least 1"));
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,8 @@ async fn run() -> Result<(), KagiError> {
         .ok_or_else(|| KagiError::Config("missing command".to_string()))?
     {
         Commands::Search(args) => {
+            args.validate().map_err(KagiError::Config)?;
+
             let options = SearchRequestOptions {
                 snap: args.snap,
                 lens: args.lens,
@@ -151,7 +153,7 @@ async fn run() -> Result<(), KagiError> {
                 cli::OutputFormat::Csv => "csv",
             };
             if let Some(follow_count) = args.follow {
-                run_search_follow(request, follow_count, profile.as_deref()).await
+                run_search_follow(request, follow_count, args.limit, profile.as_deref()).await
             } else {
                 run_search(
                     request,
@@ -160,6 +162,7 @@ async fn run() -> Result<(), KagiError> {
                     args.template,
                     args.local_cache,
                     args.cache_ttl.unwrap_or(900),
+                    args.limit,
                     profile.as_deref(),
                 )
                 .await
@@ -725,6 +728,7 @@ async fn run() -> Result<(), KagiError> {
                     no_personalized: args.no_personalized,
                 },
                 template: args.template,
+                limit: args.limit,
                 profile: profile.as_deref(),
             })
             .await
@@ -1167,6 +1171,7 @@ fn format_assistant_markdown(response: &crate::types::AssistantPromptResponse) -
         .join("\n\n")
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_search(
     request: search::SearchRequest,
     format: String,
@@ -1174,6 +1179,7 @@ async fn run_search(
     template: Option<String>,
     local_cache: bool,
     cache_ttl: u64,
+    limit: Option<usize>,
     profile: Option<&str>,
 ) -> Result<(), KagiError> {
     let inventory = load_credential_inventory_for_profile(profile)?;
@@ -1184,7 +1190,10 @@ async fn run_search(
     })
     .await?;
     record_history("search", Some(&request.query), Some(response.data.len()))?;
-    let response = apply_local_site_preferences(response)?;
+    let mut response = apply_local_site_preferences(response)?;
+    if let Some(n) = limit {
+        response.data.truncate(n);
+    }
 
     let output = match format.as_str() {
         _ if template.is_some() => {
@@ -1405,6 +1414,7 @@ struct BatchSearchConfig<'a> {
     use_color: bool,
     options: SearchRequestOptions,
     template: Option<String>,
+    limit: Option<usize>,
     profile: Option<&'a str>,
 }
 
@@ -1417,6 +1427,7 @@ async fn run_batch_search(config: BatchSearchConfig<'_>) -> Result<(), KagiError
         use_color,
         options,
         template,
+        limit,
         profile,
     } = config;
 
@@ -1460,7 +1471,12 @@ async fn run_batch_search(config: BatchSearchConfig<'_>) -> Result<(), KagiError
 
     for (query, handle) in handles {
         match handle.await {
-            Ok((completed_query, Ok(output))) => results.push((completed_query, output)),
+            Ok((completed_query, Ok(mut output))) => {
+                if let Some(n) = limit {
+                    output.data.truncate(n);
+                }
+                results.push((completed_query, output));
+            }
             Ok((completed_query, Err(e))) => {
                 error!(query = %completed_query, error = %e, "batch query failed");
                 failures.push(format!("{completed_query}: {e}"));
@@ -1551,12 +1567,16 @@ fn format_batch_failure_message(success_count: usize, failures: &[String]) -> St
 async fn run_search_follow(
     request: search::SearchRequest,
     follow_count: usize,
+    limit: Option<usize>,
     profile: Option<&str>,
 ) -> Result<(), KagiError> {
     let inventory = load_credential_inventory_for_profile(profile)?;
     let credentials = inventory.resolve_for_search(search_auth_requirement(&request))?;
-    let response =
+    let mut response =
         apply_local_site_preferences(execute_search_request(&request, credentials).await?)?;
+    if let Some(n) = limit {
+        response.data.truncate(n);
+    }
     let token = resolve_session_token(profile)?;
     let mut summaries = Vec::new();
 
@@ -2152,8 +2172,7 @@ mod tests {
         let elapsed = latest.duration_since(start);
         assert!(
             elapsed >= Duration::from_millis(150),
-            "expected throttling to delay final acquisition by at least ~200ms, got {:?}",
-            elapsed
+            "expected throttling to delay final acquisition by at least ~200ms, got {elapsed:?}"
         );
     }
 

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -253,6 +253,42 @@ fn search_command_pretty_format_prints_ranked_results() {
 }
 
 #[test]
+fn search_command_limit_truncates_results() {
+    let server = MockServer::start();
+    let _search = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/v0/search")
+            .query_param("q", "rust")
+            .header("authorization", "Bot test-api-token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "meta": api_meta(),
+                "data": [
+                    { "t": 0, "url": "https://example.com/a", "title": "A", "snippet": "first" },
+                    { "t": 0, "url": "https://example.com/b", "title": "B", "snippet": "second" },
+                    { "t": 0, "url": "https://example.com/c", "title": "C", "snippet": "third" }
+                ]
+            }));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = test_env(&server);
+    let output = run_kagi(
+        &["search", "rust", "--limit", "2", "--format", "json"],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    let data = body["data"].as_array().expect("data should be an array");
+    assert_eq!(data.len(), 2);
+    assert_eq!(data[0]["title"], "A");
+    assert_eq!(data[1]["title"], "B");
+}
+
+#[test]
 fn batch_command_returns_queries_and_results() {
     let server = MockServer::start();
     let _rust = server.mock(|when, then| {


### PR DESCRIPTION
## Summary

- Adds `--limit <N>` to `kagi search` and `kagi batch` to cap the number of results returned, removing the need for downstream `jq`/`head` post-processing for agents and scripts.
- Truncation happens locally after the Kagi response is received (Kagi search has no native count parameter), applied **after** local site preferences so pin/block re-ordering operates on the full result set first.
- `--limit` composes with `--follow`: the result list is capped first, then the top N of the capped list is summarized.
- Rejects `--limit 0` with a clear validation error in both commands.
- Mirrors the existing `news --limit` / `smallweb --limit` precedent.

## Notes

- Also fixes an unrelated pre-existing `clippy::uninlined_format_args` lint in the rate-limiter test that was blocking `make check` on `main`.
- `run_search` picks up `#[allow(clippy::too_many_arguments)]` since adding `limit` pushes it from 7 to 8 args. Refactoring to a config struct (mirroring `BatchSearchConfig`) would be cleaner but felt out of scope for this change — happy to do that in a follow-up if preferred.

## Test plan

- [x] `make check` (fmt + clippy + 172 unit tests + 13 integration tests) passes locally
- [x] New unit tests in `src/cli.rs`: `parses_search_limit_flag`, `rejects_zero_limit_on_search`, `rejects_zero_limit_on_batch`
- [x] New integration test `search_command_limit_truncates_results` in `tests/integration-cli.rs` verifies truncation against `httpmock`
- [x] Manual smoke against a real session: `kagi search "rust" --limit 3 --format json | jq '.data | length'` returns 3
- [x] `kagi search foo --limit 0` errors with `limit must be at least 1`