### PR TITLE
Xdg config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Changed
+
+- The configuration file now lives at a fixed XDG location instead of a working-directory-relative `./.kagi.toml`. It is resolved in this order: `$KAGI_CONFIG` (an explicit full file path), then `$XDG_CONFIG_HOME/kagi-cli/config.toml`, then `~/.config/kagi-cli/config.toml`. The file is still created with `0600` permissions, and the `KAGI_API_KEY`/`KAGI_API_TOKEN`/`KAGI_SESSION_TOKEN` environment variables continue to take precedence over it.
+
+  **Breaking:** credentials previously saved in a working-directory-relative `./.kagi.toml` are no longer read. Run `kagi auth set` (or `kagi auth`) once to re-save them at the new location, or point `KAGI_CONFIG` at your existing file.
+
 ## [0.10.0]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Pull requests will not be rejected solely because AI was used. They may be rejec
 
 ## Auth and Test Safety
 
-- Do not commit `.env`, `.kagi.toml`, session tokens, or API tokens
+- Do not commit `.env`, credential files, session tokens, or API tokens
 - Prefer unit tests and parser fixtures over live authenticated tests
 - If a change requires live verification, document the exact manual steps in the pull request
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 `kagi` is a terminal CLI for Kagi that gives you command-line access to search, quick answers, ask-page, assistant, translate, summarization, public feeds through `news` and `smallweb`, paid API commands like `fastgpt` and `enrich`, and account-level settings like lenses, custom assistants, custom bangs, and redirect rules. it is built for people who want one command surface for interactive use, shell workflows, and structured JSON output.
 
-the main setup path is `kagi auth`. on a real terminal it opens a guided setup flow where you choose `Session Link`, `API Key`, or `Legacy API Token`, get the official instructions inline, paste the credential, save it to `./.kagi.toml`, and validate it immediately. if you also use Kagi's paid API, the same wizard can add that too.
+the main setup path is `kagi auth`. on a real terminal it opens a guided setup flow where you choose `Session Link`, `API Key`, or `Legacy API Token`, get the official instructions inline, paste the credential, save it to `~/.config/kagi-cli/config.toml`, and validate it immediately. if you also use Kagi's paid API, the same wizard can add that too.
 
 [documentation](https://kagi.micr.dev) | [npm](https://www.npmjs.com/package/kagi-cli) | [mcp](https://github.com/Microck/kagi-mcp)
 
@@ -81,7 +81,7 @@ the wizard is the default setup path. it guides you through:
 - `Session Link` from `https://kagi.com/settings/user_details`
 - `API Key` from `https://kagi.com/api/keys`
 - `Legacy API Token` from `https://kagi.com/settings/api`
-- saving into `./.kagi.toml`
+- saving into `~/.config/kagi-cli/config.toml`
 - immediate validation
 
 non-interactive alternative:
@@ -153,8 +153,8 @@ notes:
 
 - `kagi auth` is interactive on TTYs and becomes the default onboarding path
 - `kagi auth set --session-token` accepts either the raw token or the full session-link URL
-- `kagi --profile work ...` reads `[profiles.work.auth]` from `.kagi.toml`
-- environment variables override `.kagi.toml`
+- `kagi --profile work ...` reads `[profiles.work.auth]` from the config file (`~/.config/kagi-cli/config.toml`)
+- environment variables override `~/.config/kagi-cli/config.toml`
 - base `kagi search` defaults to the session-token path when both credentials are present
 - set `[auth] preferred_auth = "api"` if you want base search to prefer the API path instead
 - API-first base search falls back to the session-token path when the API key is rejected, including quota and rate-limit failures

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -49,7 +49,7 @@ kagi auth
 Opens a guided TTY wizard that walks through:
 - Choosing Session Link, API Key, or Legacy API Token
 - Pasting credentials
-- Saving to `./.kagi.toml`
+- Saving to `~/.config/kagi-cli/config.toml`
 - Immediate validation
 
 ### Non-Interactive Setup
@@ -77,7 +77,7 @@ export KAGI_API_TOKEN='...'
 | `KAGI_API_TOKEN` | summarize, fastgpt, enrich web, enrich news |
 | none | news, smallweb, auth status, --help |
 
-Environment variables override `./.kagi.toml`. When a session token and API key are both present, base `kagi search` defaults to the session token; set `[auth] preferred_auth = "api"` in config to prefer the API key.
+Environment variables override `~/.config/kagi-cli/config.toml`. When a session token and API key are both present, base `kagi search` defaults to the session token; set `[auth] preferred_auth = "api"` in config to prefer the API key.
 
 ## Commands
 

--- a/docs/commands/auth.mdx
+++ b/docs/commands/auth.mdx
@@ -5,7 +5,7 @@ description: "Reference for the kagi auth wizard and non-interactive credential 
 
 # `kagi auth`
 
-`kagi auth` is the main onboarding path for this CLI. On a real terminal, it launches an interactive setup wizard that lets you choose `Session Link`, `API Key`, or `Legacy API Token`, shows the official Kagi settings page for that credential, accepts a paste, saves into `./.kagi.toml`, and validates the selected credential immediately.
+`kagi auth` is the main onboarding path for this CLI. On a real terminal, it launches an interactive setup wizard that lets you choose `Session Link`, `API Key`, or `Legacy API Token`, shows the official Kagi settings page for that credential, accepts a paste, saves into `~/.config/kagi-cli/config.toml`, and validates the selected credential immediately.
 
 ![Auth command demo](/images/demos/auth.gif)
 
@@ -34,7 +34,7 @@ The wizard flow is:
 4. accepts the pasted value
 5. asks before overwriting an existing config value of the same type
 6. validates the selected credential
-7. saves to `./.kagi.toml`
+7. saves to `~/.config/kagi-cli/config.toml`
 8. warns if an environment variable will still override what you saved
 
 ### Session Link Path
@@ -109,7 +109,7 @@ preferred auth for base search: session
 api key: not configured
 legacy api token: not configured
 session token: configured via config
-config path: .kagi.toml
+config path: ~/.config/kagi-cli/config.toml
 precedence: env > selected profile config > default config; base search defaults to session unless preferred_auth = "api"; lens search requires session token
 ```
 
@@ -155,7 +155,7 @@ Options:
 
 Behavior:
 
-- creates `./.kagi.toml` when needed
+- creates `~/.config/kagi-cli/config.toml` when needed
 - preserves the other credential if you only set one
 - normalizes full Session Link URLs into the raw token value
 - writes the config file with restrictive permissions on Unix
@@ -166,9 +166,9 @@ The CLI resolves credentials in this order:
 
 1. `KAGI_API_KEY` / `KAGI_API_TOKEN` / `KAGI_SESSION_TOKEN`
 2. selected profile config, such as `[profiles.work.auth]`
-3. default `./.kagi.toml` `[auth]`
+3. default `~/.config/kagi-cli/config.toml` `[auth]`
 
-Environment variables override the config file. Use `--profile <NAME>` to select a named profile from `.kagi.toml`:
+The config file is resolved from `$KAGI_CONFIG` (an explicit full path), then `$XDG_CONFIG_HOME/kagi-cli/config.toml`, then `~/.config/kagi-cli/config.toml`. Environment variables override the config file. Use `--profile <NAME>` to select a named profile from the config file (`~/.config/kagi-cli/config.toml`):
 
 ```toml
 [profiles.work.auth]
@@ -220,7 +220,7 @@ kagi search --format pretty "what changed in rust 1.86?"
 ## Security Notes
 
 - `auth status` and `auth check` never print the secret values
-- `./.kagi.toml` is local plaintext config, so keep it out of version control
+- `~/.config/kagi-cli/config.toml` is local plaintext config, so keep it out of version control
 - on Unix, the CLI writes restrictive file permissions when saving the config
 - environment variables still override config and may be preferable in CI/CD
 

--- a/docs/guides/advanced-usage.mdx
+++ b/docs/guides/advanced-usage.mdx
@@ -691,8 +691,9 @@ chmod 600 "$TEMP_FILE"
 #!/bin/bash
 # Prevent accidental token commits
 
-# Add to .gitignore
-echo ".kagi.toml" >> .gitignore
+# The config file now lives at ~/.config/kagi-cli/config.toml, outside your
+# repositories, so it no longer needs to be added to .gitignore.
+# Still guard against other accidental secret commits:
 echo ".env" >> .gitignore
 echo "*token*" >> .gitignore
 

--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -15,7 +15,7 @@ On a real terminal, the default setup path is:
 kagi auth
 ```
 
-The wizard lets you choose `Session Link`, `API Key`, or `Legacy API Token`, points you to the correct Kagi settings page, accepts a paste, saves into `./.kagi.toml`, and validates the selected credential immediately.
+The wizard lets you choose `Session Link`, `API Key`, or `Legacy API Token`, points you to the correct Kagi settings page, accepts a paste, saves into `~/.config/kagi-cli/config.toml`, and validates the selected credential immediately.
 
 Use `kagi auth set ...` only when you want a non-interactive or scripted flow.
 
@@ -219,10 +219,14 @@ env:
 
 ### Method 2: Configuration File
 
-The `.kagi.toml` file provides persistent configuration:
+The config file provides persistent configuration:
 
 **Location:**
-- `./.kagi.toml` in the current working directory
+- `~/.config/kagi-cli/config.toml`
+
+The config file is resolved from `$KAGI_CONFIG` (an explicit full path), then `$XDG_CONFIG_HOME/kagi-cli/config.toml`, then `~/.config/kagi-cli/config.toml`.
+
+> **Migration note:** A pre-existing `./.kagi.toml` in your working directory is no longer read. Re-run `kagi auth set` (or `kagi auth`) once to re-save your credentials at the new location, or set `KAGI_CONFIG` to the old file path.
 
 **File format:**
 
@@ -260,14 +264,15 @@ kagi auth set --session-token 'https://kagi.com/search?token=SESSION_TOKEN' --ap
 
 ```bash
 # macOS/Linux
-cat > ./.kagi.toml << 'EOF'
+mkdir -p ~/.config/kagi-cli
+cat > ~/.config/kagi-cli/config.toml << 'EOF'
 [auth]
 api_token = "your_api_token"
 session_token = "https://kagi.com/search?token=your_session_token"
 EOF
 
 # Set secure permissions
-chmod 600 ./.kagi.toml
+chmod 600 ~/.config/kagi-cli/config.toml
 ```
 
 ```powershell
@@ -277,7 +282,8 @@ $content = @"
 api_token = `"your_api_token`"
 session_token = `"https://kagi.com/search?token=your_session_token`"
 "@
-$content | Out-File -FilePath ".kagi.toml" -Encoding utf8
+New-Item -ItemType Directory -Force -Path "$HOME\.config\kagi-cli" | Out-Null
+$content | Out-File -FilePath "$HOME\.config\kagi-cli\config.toml" -Encoding utf8
 ```
 
 ### Precedence Rules
@@ -286,9 +292,11 @@ Credentials are resolved in this order (first match wins):
 
 ```
 1. Environment Variables (KAGI_API_KEY, KAGI_API_TOKEN, KAGI_SESSION_TOKEN)
-2. Configuration File (`./.kagi.toml`)
+2. Configuration File (`~/.config/kagi-cli/config.toml`)
 3. Missing (error for commands requiring auth)
 ```
+
+The config file is resolved from `$KAGI_CONFIG` (an explicit full path), then `$XDG_CONFIG_HOME/kagi-cli/config.toml`, then `~/.config/kagi-cli/config.toml`.
 
 This means:
 - Environment variables override config file values
@@ -300,7 +308,7 @@ This means:
 
 ```bash
 # Config file has default session token
-cat ./.kagi.toml
+cat ~/.config/kagi-cli/config.toml
 # [auth]
 # session_token = "https://kagi.com/search?token=DEFAULT_TOKEN"
 
@@ -335,7 +343,7 @@ selected: none
 api key: not configured
 legacy api token: not configured
 session token: not configured
-config path: .kagi.toml
+config path: ~/.config/kagi-cli/config.toml
 ```
 
 Session token only:
@@ -344,7 +352,7 @@ selected: session-token (config)
 api key: not configured
 legacy api token: not configured
 session token: configured via config
-config path: .kagi.toml
+config path: ~/.config/kagi-cli/config.toml
 ```
 
 API key and session token:
@@ -353,7 +361,7 @@ selected: api-key (env)
 api key: configured via env
 legacy api token: not configured
 session token: configured via config
-config path: .kagi.toml
+config path: ~/.config/kagi-cli/config.toml
 ```
 
 ### Validating Credentials
@@ -497,7 +505,7 @@ kagi search "test"
 **Scenario 2: API-first mode works**
 ```bash
 export KAGI_API_KEY='valid_key'
-# .kagi.toml contains: [auth] preferred_auth = "api"
+# ~/.config/kagi-cli/config.toml contains: [auth] preferred_auth = "api"
 kagi search "test"
 # Uses Search API, returns results
 ```
@@ -506,7 +514,7 @@ kagi search "test"
 ```bash
 export KAGI_API_KEY='valid_key'
 export KAGI_SESSION_TOKEN='also_valid'
-# .kagi.toml contains: [auth] preferred_auth = "api"
+# ~/.config/kagi-cli/config.toml contains: [auth] preferred_auth = "api"
 kagi search "test"
 # Tries Search API and gets auth error
 # Falls back to session token path
@@ -527,7 +535,7 @@ kagi search "test"
 
 **DO:**
 - ✅ Use `kagi auth` for local setup so the CLI validates the credential as you save it
-- ✅ Store tokens in `./.kagi.toml` with 600 permissions
+- ✅ Store tokens in `~/.config/kagi-cli/config.toml` with 600 permissions
 - ✅ Use environment variables in CI/CD secrets
 - ✅ Use secret managers (1Password, Vault, etc.)
 - ✅ Rotate tokens periodically
@@ -742,7 +750,7 @@ $env:KAGI_SESSION_TOKEN = [System.Runtime.InteropServices.Marshal]::PtrToStringA
 
 ### Multiple Profiles
 
-For users with multiple Kagi accounts, prefer named profiles in one `.kagi.toml`:
+For users with multiple Kagi accounts, prefer named profiles in one config file (`~/.config/kagi-cli/config.toml`):
 
 ```toml
 [auth]

--- a/docs/guides/installation.mdx
+++ b/docs/guides/installation.mdx
@@ -547,7 +547,7 @@ To completely remove *kagi*:
 rm ~/.local/bin/kagi
 
 # Remove config
-rm ./.kagi.toml
+rm ~/.config/kagi-cli/config.toml
 
 # Remove from PATH (edit ~/.bashrc, ~/.zshrc, etc.)
 ```
@@ -559,7 +559,7 @@ rm ./.kagi.toml
 Remove-Item -Recurse -Force "$env:LOCALAPPDATA\kagi"
 
 # Remove config
-Remove-Item ".kagi.toml"
+Remove-Item "$HOME\.config\kagi-cli\config.toml"
 
 # Remove from PATH via System Properties
 ```

--- a/docs/guides/quickstart.mdx
+++ b/docs/guides/quickstart.mdx
@@ -90,7 +90,7 @@ selected: none
 api key: not configured
 legacy api token: not configured
 session token: not configured
-config path: .kagi.toml
+config path: ~/.config/kagi-cli/config.toml
 ```
 
 This is expected - we'll configure credentials next.
@@ -150,7 +150,7 @@ Save the token to a config file:
 kagi auth set --session-token 'https://kagi.com/search?token=YOUR_TOKEN_HERE'
 ```
 
-This creates `./.kagi.toml` with your token. The CLI accepts either:
+This creates `~/.config/kagi-cli/config.toml` with your token. The CLI accepts either:
 - The full Session Link URL (recommended)
 - Just the raw token value
 
@@ -167,7 +167,7 @@ selected: session-token (config)
 api key: not configured
 legacy api token: not configured
 session token: configured via config
-config path: .kagi.toml
+config path: ~/.config/kagi-cli/config.toml
 ```
 
 ### Testing Subscriber Features
@@ -306,9 +306,9 @@ See the [Auth Matrix](/reference/auth-matrix) for the complete command-to-token 
 
 Now that you've tested everything, let's create a robust configuration.
 
-### The .kagi.toml File
+### The config file
 
-Kagi uses a TOML configuration file located at `./.kagi.toml`.
+Kagi uses a TOML configuration file located at `~/.config/kagi-cli/config.toml`.
 
 **Basic configuration:**
 
@@ -322,14 +322,15 @@ session_token = "your_session_token_here"
 
 ```bash
 # Create the file
-cat > ./.kagi.toml << 'EOF'
+mkdir -p ~/.config/kagi-cli
+cat > ~/.config/kagi-cli/config.toml << 'EOF'
 [auth]
 api_token = "your_api_token_here"
 session_token = "your_session_token_here"
 EOF
 
 # Set secure permissions
-chmod 600 ./.kagi.toml
+chmod 600 ~/.config/kagi-cli/config.toml
 ```
 
 ### Configuration Precedence
@@ -337,9 +338,9 @@ chmod 600 ./.kagi.toml
 Kagi resolves credentials in this order (first match wins):
 
 1. **Environment variables** (`KAGI_API_KEY`, `KAGI_API_TOKEN`, `KAGI_SESSION_TOKEN`)
-2. **Config file** (`./.kagi.toml`)
+2. **Config file** (`~/.config/kagi-cli/config.toml`)
 
-This means you can override file configuration with environment variables for specific workflows or CI/CD.
+The config file is resolved from `$KAGI_CONFIG` (an explicit full path), then `$XDG_CONFIG_HOME/kagi-cli/config.toml`, then `~/.config/kagi-cli/config.toml`. This means you can override file configuration with environment variables for specific workflows or CI/CD.
 
 ### Shell Profile Integration
 
@@ -379,7 +380,7 @@ $env:KAGI_API_TOKEN = 'your_api_token'
 
 ### Security Best Practices
 
-1. **File permissions**: Set `./.kagi.toml` to 600 (readable only by you)
+1. **File permissions**: Set `~/.config/kagi-cli/config.toml` to 600 (readable only by you)
 2. **Environment variables**: Don't commit these to version control
 3. **Token rotation**: Regenerate tokens periodically
 4. **Separate contexts**: Use different tokens for different environments (dev/staging/prod)

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -179,7 +179,8 @@ kagi auth check
 kagi auth set --session-token 'https://kagi.com/search?token=YOUR_TOKEN'
 
 # Or manually
-cat > ./.kagi.toml << 'EOF'
+mkdir -p ~/.config/kagi-cli
+cat > ~/.config/kagi-cli/config.toml << 'EOF'
 [auth]
 session_token = "https://kagi.com/search?token=YOUR_TOKEN"
 EOF
@@ -789,7 +790,9 @@ kagi auth check
 
 ### Config File Location
 
-- Repo checkout: `./.kagi.toml`
+- Default: `~/.config/kagi-cli/config.toml`
+
+The config file is resolved from `$KAGI_CONFIG` (an explicit full path), then `$XDG_CONFIG_HOME/kagi-cli/config.toml`, then `~/.config/kagi-cli/config.toml`. A pre-existing `./.kagi.toml` is no longer read; re-run `kagi auth set` (or `kagi auth`) to re-save credentials at the new location, or set `KAGI_CONFIG` to the old file path.
 
 ### Shell Syntax
 

--- a/docs/project/support.mdx
+++ b/docs/project/support.mdx
@@ -25,7 +25,7 @@ Use the repo's issue tracker and support channels for:
 Do not commit:
 
 - `.env`
-- `.kagi.toml`
+- `~/.config/kagi-cli/config.toml`
 - session tokens
 - API tokens
 

--- a/docs/reference/auth-matrix.mdx
+++ b/docs/reference/auth-matrix.mdx
@@ -108,7 +108,7 @@ flowchart TD
 - **Purpose:** Interactive setup wizard
 - **Network:** Yes, during credential validation
 - **Uses:** The credential the user just pasted
-- **Writes:** `./.kagi.toml`
+- **Writes:** `~/.config/kagi-cli/config.toml`
 - **TTY only:** In non-interactive environments, use `auth set`, `status`, or `check`
 
 #### `kagi auth status`
@@ -129,7 +129,7 @@ flowchart TD
 
 - **Purpose:** Save credentials to file
 - **Network:** No
-- **Writes:** `./.kagi.toml`
+- **Writes:** `~/.config/kagi-cli/config.toml`
 - **Creates:** Config file if doesn't exist
 
 ### Content Commands
@@ -231,16 +231,18 @@ Works without authentication:
 ```
 1. Environment Variables (KAGI_API_KEY, KAGI_API_TOKEN, KAGI_SESSION_TOKEN)
    ↓ (if not set)
-2. Configuration File (`./.kagi.toml`)
+2. Configuration File (`~/.config/kagi-cli/config.toml`)
    ↓ (if not set)
 3. Missing (error for commands requiring auth)
 ```
+
+The config file is resolved from `$KAGI_CONFIG` (an explicit full path), then `$XDG_CONFIG_HOME/kagi-cli/config.toml`, then `~/.config/kagi-cli/config.toml`. Environment variables override the config file.
 
 ### Example Scenarios
 
 **Scenario 1: Multiple credentials in file**
 ```toml
-# ./.kagi.toml
+# ~/.config/kagi-cli/config.toml
 [auth]
 api_token = "api123"
 api_key = "key123"
@@ -255,7 +257,7 @@ session_token = "session456"
 **Scenario 2: Mixed sources**
 ```bash
 export KAGI_API_KEY="key789"
-# ./.kagi.toml has session_token only
+# ~/.config/kagi-cli/config.toml has session_token only
 ```
 - `search`: Uses env API key when `[auth.preferred_auth] = "api"`
 - `summarize --subscriber`: Uses file session token
@@ -264,7 +266,7 @@ export KAGI_API_KEY="key789"
 **Scenario 3: Environment overrides file**
 ```bash
 export KAGI_SESSION_TOKEN="special_session"
-# ./.kagi.toml has different session_token
+# ~/.config/kagi-cli/config.toml has different session_token
 ```
 - `search`: Uses env session token (not API, so tries web)
 - `assistant`: Uses env session token

--- a/docs/reference/coverage.mdx
+++ b/docs/reference/coverage.mdx
@@ -79,7 +79,7 @@ These require no authentication:
 | `batch` via stdin | Parallel search from stdin lines | API or Session | ✅ |
 | `auth` | Credential management | None | ✅ |
 | `completion` | Generate and install shell completions | None | Implemented |
-| `--profile` | Named auth profiles from `.kagi.toml` | None | ✅ |
+| `--profile` | Named auth profiles from the config file (`~/.config/kagi-cli/config.toml`) | None | ✅ |
 | `summarize` | Public API summarizer | API | ✅ |
 | `summarize --subscriber` | Web summarizer | Session | ✅ |
 | `summarize --filter` | Summarize stdin items as URLs or text | API or Session | ✅ |

--- a/docs/reference/error-reference.mdx
+++ b/docs/reference/error-reference.mdx
@@ -147,7 +147,7 @@ Error: Auth error: Kagi Search API request rejected: HTTP 400 Bad Request; Insuf
 
 **Message:**
 ```
-config path: .kagi.toml
+config path: ~/.config/kagi-cli/config.toml
 ```
 
 **Meaning:** No configuration file exists yet.
@@ -181,13 +181,13 @@ Error: Permission denied (os error 13)
 **Solution:**
 ```bash
 # Check permissions
-ls -la ./.kagi.toml
+ls -la ~/.config/kagi-cli/config.toml
 
 # Fix permissions
-chmod 600 ./.kagi.toml
+chmod 600 ~/.config/kagi-cli/config.toml
 
 # Or recreate
-rm ./.kagi.toml
+rm ~/.config/kagi-cli/config.toml
 kagi auth set --session-token 'YOUR_TOKEN'
 ```
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -15,7 +15,12 @@ use serde::Deserialize;
 
 use crate::error::KagiError;
 
-const DEFAULT_CONFIG_PATH: &str = ".kagi.toml";
+/// Environment variable that overrides the full path to the config file.
+pub const CONFIG_PATH_ENV: &str = "KAGI_CONFIG";
+/// Directory name, under the XDG config home, that holds the config file.
+const CONFIG_DIR_NAME: &str = "kagi-cli";
+/// File name of the config file within the config directory.
+const CONFIG_FILE_NAME: &str = "config.toml";
 pub const API_KEY_ENV: &str = "KAGI_API_KEY";
 pub const API_TOKEN_ENV: &str = "KAGI_API_TOKEN";
 pub const SESSION_TOKEN_ENV: &str = "KAGI_SESSION_TOKEN";
@@ -262,6 +267,41 @@ pub struct ConfigAuthSnapshot {
     pub search_preference: SearchAuthPreference,
 }
 
+/// Resolves the path to the kagi config file.
+///
+/// Resolution order:
+/// 1. The `KAGI_CONFIG` environment variable, used verbatim as the full file
+///    path when set to a non-empty value.
+/// 2. `$XDG_CONFIG_HOME/kagi-cli/config.toml`.
+/// 3. `$HOME/.config/kagi-cli/config.toml` when `XDG_CONFIG_HOME` is unset.
+pub fn default_config_path() -> PathBuf {
+    if let Some(path) = env::var_os(CONFIG_PATH_ENV)
+        .map(PathBuf::from)
+        .filter(|value| !value.as_os_str().is_empty())
+    {
+        return path;
+    }
+
+    xdg_config_home()
+        .join(CONFIG_DIR_NAME)
+        .join(CONFIG_FILE_NAME)
+}
+
+fn xdg_config_home() -> PathBuf {
+    env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|value| !value.as_os_str().is_empty())
+        .unwrap_or_else(|| home_dir().join(".config"))
+}
+
+fn home_dir() -> PathBuf {
+    env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .filter(|value| !value.as_os_str().is_empty())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
 /// Loads the credential inventory from the default config path and environment variables.
 ///
 /// # Returns
@@ -282,7 +322,7 @@ pub fn load_credential_inventory() -> Result<CredentialInventory, KagiError> {
 pub fn load_credential_inventory_for_profile(
     profile: Option<&str>,
 ) -> Result<CredentialInventory, KagiError> {
-    load_credential_inventory_from_path(Path::new(DEFAULT_CONFIG_PATH), profile)
+    load_credential_inventory_from_path(&default_config_path(), profile)
 }
 
 fn load_credential_inventory_from_path(
@@ -388,7 +428,7 @@ pub fn format_status(inventory: &CredentialInventory) -> String {
 /// # Errors
 /// Returns `KagiError::Config` if the config file cannot be read or parsed.
 pub fn load_config_auth_snapshot() -> Result<ConfigAuthSnapshot, KagiError> {
-    load_config_auth_snapshot_from_path(Path::new(DEFAULT_CONFIG_PATH))
+    load_config_auth_snapshot_from_path(&default_config_path())
 }
 
 fn load_config_auth_snapshot_from_path(
@@ -464,7 +504,7 @@ fn select_auth_config<'a>(
         .and_then(|profiles| profiles.get(profile))
         .ok_or_else(|| {
             KagiError::Config(format!(
-                "profile `{profile}` was not found in .kagi.toml. Run `kagi auth status --profile {profile}` to confirm the name, or add [profiles.{profile}.auth]"
+                "profile `{profile}` was not found in the kagi config file. Run `kagi auth status --profile {profile}` to confirm the name, or add [profiles.{profile}.auth]"
             ))
         })?;
 
@@ -593,7 +633,7 @@ fn save_credentials_with_preference_for_profile(
     preferred_auth: Option<SearchAuthPreference>,
 ) -> Result<CredentialInventory, KagiError> {
     save_credentials_with_preference_to_path(
-        Path::new(DEFAULT_CONFIG_PATH),
+        &default_config_path(),
         profile,
         api_key,
         api_token,
@@ -733,6 +773,14 @@ fn read_config_file(path: &Path) -> Result<ConfigFile, KagiError> {
 
 fn write_config_file_atomically(path: &Path, raw: &str) -> Result<(), KagiError> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    if !parent.as_os_str().is_empty() {
+        fs::create_dir_all(parent).map_err(|error| {
+            KagiError::Config(format!(
+                "failed to create config directory {}: {error}",
+                parent.display()
+            ))
+        })?;
+    }
     let file_name = path
         .file_name()
         .map(|value| value.to_string_lossy().into_owned())
@@ -921,7 +969,7 @@ mod tests {
             api_token: None,
             session_token: None,
             search_preference: SearchAuthPreference::Session,
-            config_path: PathBuf::from(DEFAULT_CONFIG_PATH),
+            config_path: default_config_path(),
             profile: None,
         };
 
@@ -943,7 +991,7 @@ mod tests {
             api_token: None,
             session_token: None,
             search_preference: SearchAuthPreference::Session,
-            config_path: PathBuf::from(DEFAULT_CONFIG_PATH),
+            config_path: default_config_path(),
             profile: None,
         };
 
@@ -969,7 +1017,7 @@ mod tests {
                 value: "session".to_string(),
             }),
             search_preference: SearchAuthPreference::Session,
-            config_path: PathBuf::from(DEFAULT_CONFIG_PATH),
+            config_path: default_config_path(),
             profile: None,
         };
 
@@ -995,7 +1043,7 @@ mod tests {
                 value: "session".to_string(),
             }),
             search_preference: SearchAuthPreference::Session,
-            config_path: PathBuf::from(DEFAULT_CONFIG_PATH),
+            config_path: default_config_path(),
             profile: None,
         };
 
@@ -1020,7 +1068,7 @@ mod tests {
                 value: "session".to_string(),
             }),
             search_preference: SearchAuthPreference::Api,
-            config_path: PathBuf::from(DEFAULT_CONFIG_PATH),
+            config_path: default_config_path(),
             profile: None,
         };
 
@@ -1041,7 +1089,7 @@ mod tests {
             }),
             session_token: None,
             search_preference: SearchAuthPreference::Api,
-            config_path: PathBuf::from(DEFAULT_CONFIG_PATH),
+            config_path: default_config_path(),
             profile: None,
         };
 
@@ -1085,7 +1133,7 @@ mod tests {
             }),
             session_token: None,
             search_preference: SearchAuthPreference::Session,
-            config_path: PathBuf::from(DEFAULT_CONFIG_PATH),
+            config_path: default_config_path(),
             profile: None,
         };
 
@@ -1240,5 +1288,42 @@ mod tests {
                 & 0o777;
             assert_eq!(mode, 0o600);
         }
+    }
+
+    #[test]
+    fn config_path_prefers_explicit_override() {
+        let _guard = lock_env();
+        let _override = set_env_var(CONFIG_PATH_ENV, "/tmp/custom/kagi-config.toml");
+
+        assert_eq!(
+            default_config_path(),
+            PathBuf::from("/tmp/custom/kagi-config.toml")
+        );
+    }
+
+    #[test]
+    fn config_path_uses_xdg_config_home_when_no_override() {
+        let _guard = lock_env();
+        let _override = set_env_var(CONFIG_PATH_ENV, "");
+        let _xdg = set_env_var("XDG_CONFIG_HOME", "/tmp/xdg-config");
+
+        let expected = PathBuf::from("/tmp/xdg-config")
+            .join("kagi-cli")
+            .join("config.toml");
+        assert_eq!(default_config_path(), expected);
+    }
+
+    #[test]
+    fn config_path_falls_back_to_home_config_dir() {
+        let _guard = lock_env();
+        let _override = set_env_var(CONFIG_PATH_ENV, "");
+        let _xdg = set_env_var("XDG_CONFIG_HOME", "");
+        let _home = set_env_var("HOME", "/home/tester");
+
+        let expected = PathBuf::from("/home/tester")
+            .join(".config")
+            .join("kagi-cli")
+            .join("config.toml");
+        assert_eq!(default_config_path(), expected);
     }
 }

--- a/src/auth_wizard.rs
+++ b/src/auth_wizard.rs
@@ -120,7 +120,9 @@ pub async fn run_auth_wizard() -> Result<(), KagiError> {
         "Current Auth",
         format_inventory_summary(&inventory),
     ))?;
-    wizard_io(log::info("Environment variables override .kagi.toml."))?;
+    wizard_io(log::info(
+        "Environment variables override the saved config file.",
+    ))?;
 
     let Some(kind) = prompt_result(
         cliclack::select("Choose an auth method")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -240,7 +240,7 @@ pub struct Cli {
     #[arg(long, value_name = "SHELL", value_enum)]
     pub generate_completion: Option<CompletionShell>,
 
-    /// Use a named profile from .kagi.toml instead of the default auth block
+    /// Use a named profile from the kagi config file instead of the default auth block
     #[arg(long, global = true, value_name = "NAME")]
     pub profile: Option<String>,
 
@@ -630,15 +630,15 @@ pub enum AuthSubcommand {
 #[derive(Debug, Args)]
 /// Arguments for `auth set` (store a credential).
 pub struct AuthSetArgs {
-    /// Kagi API key for current /api/v1 endpoints to save into .kagi.toml
+    /// Kagi API key for current /api/v1 endpoints to save into the kagi config file
     #[arg(long, value_name = "KEY")]
     pub api_key: Option<String>,
 
-    /// Legacy Kagi API token for /api/v0 endpoints to save into .kagi.toml
+    /// Legacy Kagi API token for /api/v0 endpoints to save into the kagi config file
     #[arg(long, value_name = "TOKEN")]
     pub api_token: Option<String>,
 
-    /// Kagi session token or full Session Link URL to save into .kagi.toml
+    /// Kagi session token or full Session Link URL to save into the kagi config file
     #[arg(long, value_name = "TOKEN_OR_URL")]
     pub session_token: Option<String>,
 }

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -86,6 +86,20 @@ fn isolate_command_home(command: &mut Command, cwd: &Path) {
         .env("XDG_DATA_HOME", cwd.join(".local").join("share"));
 }
 
+/// Path to the kagi config file for a sandboxed run, matching the isolated
+/// `XDG_CONFIG_HOME` set by `isolate_command_home`.
+fn config_path(cwd: &Path) -> std::path::PathBuf {
+    cwd.join(".config").join("kagi-cli").join("config.toml")
+}
+
+/// Seeds the kagi config file for a sandboxed run, creating parent directories.
+fn write_config(cwd: &Path, contents: &str) {
+    let path = config_path(cwd);
+    fs::create_dir_all(path.parent().expect("config path has a parent"))
+        .expect("config directory should create");
+    fs::write(path, contents).expect("config should write");
+}
+
 fn assert_success(output: &Output) {
     assert!(
         output.status.success(),
@@ -691,11 +705,7 @@ fn search_command_falls_back_to_session_when_api_is_rate_limited() {
     });
 
     let tempdir = TempDir::new().expect("tempdir");
-    fs::write(
-        tempdir.path().join(".kagi.toml"),
-        "[auth]\npreferred_auth = \"api\"\n",
-    )
-    .expect("config should write");
+    write_config(tempdir.path(), "[auth]\npreferred_auth = \"api\"\n");
     let env = vec![
         ("KAGI_API_KEY", API_KEY.to_string()),
         ("KAGI_SESSION_TOKEN", "test-session".to_string()),
@@ -929,7 +939,7 @@ fn auth_set_saves_api_key_and_legacy_api_token_separately() {
     );
 
     assert_success(&output);
-    let raw = fs::read_to_string(tempdir.path().join(".kagi.toml")).expect("config should exist");
+    let raw = fs::read_to_string(config_path(tempdir.path())).expect("config should exist");
     assert!(raw.contains("api_key = \"current-key\""));
     assert!(raw.contains("api_token = \"legacy-token\""));
 }


### PR DESCRIPTION
## Summary

I made it use XDG config file locations (~/.config/kagi-cli/config.toml) instead of ./.kagi.toml for storing api keys. IDK if there's a specific rationale for using the cwd (individual per-project tokens?), but having to re-paste the token each time was annoying, so.

## Verification

- [o] `cargo fmt --check`
- [o] `cargo clippy --all-targets --all-features -- -D warnings`
- [o] `cargo test -q`

## Docs

- [o] README updated if user-facing behavior changed
- [o] CHANGELOG updated for notable user-facing changes