### PR TITLE
feat: add CLI contract workflows

### DIFF
--- a/.facts
+++ b/.facts
@@ -1,0 +1,29 @@
+
+# domain
+- a Contract is a prompt-mode output shape that the assistant command asks Kagi Assistant to return as JSON and validates before printing
+- an ErrorEnvelope is an opt-in JSON stderr object for command failures with stable code, category, retryable, message, and suggested_commands fields
+
+# cli
+
+## assistant
+- label: kagi assistant --contract decision validates the final assistant reply as a JSON object containing decision, rationale, and next_actions before printing it
+  command: cargo test --test integration-cli assistant_contract_decision_prints_validated_json -- --exact
+  tags: [implemented]
+- label: kagi assistant --contract-file accepts a small JSON contract file with required top-level string keys and rejects assistant replies that do not satisfy it
+  command: cargo test --test integration-cli assistant_contract_file_rejects_missing_required_key -- --exact
+  tags: [implemented]
+
+## errors
+- label: runtime command failures can opt into JSON stderr with --error-format json or KAGI_ERROR_FORMAT=json
+  command: cargo test --test integration-cli json_error_format_prints_structured_stderr -- --exact
+  tags: [implemented]
+
+## search
+- label: kagi search --lens accepts an enabled lens exact name, resolves it through the authenticated lens settings page, and sends the current numeric lens position to search
+  command: cargo test --test integration-cli search_lens_name_resolves_to_current_position -- --exact
+  tags: [implemented]
+
+## extract
+- label: kagi extract --filter reads HTTPS URLs from stdin and writes one compact JSONL record per input in order, including per-item errors without corrupting stdout
+  command: cargo test --test integration-cli extract_filter_prints_ordered_jsonl_records -- --exact
+  tags: [implemented]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/docs/commands/assistant.mdx
+++ b/docs/commands/assistant.mdx
@@ -14,6 +14,8 @@ Prompt Kagi Assistant, continue an existing thread, use a saved assistant profil
 ```bash
 kagi assistant [OPTIONS] <QUERY>
 kagi assistant --stream [--stream-output text|json] <QUERY>
+kagi assistant --contract decision <QUERY>
+kagi assistant --contract-file ./contract.json <QUERY>
 kagi assistant thread list
 kagi assistant thread get <THREAD_ID>
 kagi assistant thread delete <THREAD_ID>
@@ -75,6 +77,39 @@ Possible values:
 kagi assistant --format pretty "What changed in Rust 1.86?"
 kagi assistant --format markdown "Write a release summary"
 ```
+
+#### `--contract <NAME>`
+
+Ask Assistant to return only JSON that satisfies a built-in contract, then validate the final reply before printing it. Contract mode supports `--format json` and `--format compact`.
+
+Supported built-ins:
+
+- `decision` - requires `decision`, `rationale`, and `next_actions`
+- `checklist` - requires `items`
+- `plan` - requires `steps`
+
+```bash
+kagi assistant --contract decision "Should we ship this release?"
+```
+
+If the first reply is invalid, the CLI sends one repair prompt in the same thread. If the repaired reply still fails validation, the command exits with a contract error.
+
+#### `--contract-file <PATH>`
+
+Load a small JSON contract file. The supported subset is a top-level object with `required` and optional `properties.<key>.type` fields:
+
+```json
+{
+  "type": "object",
+  "required": ["summary", "verdict"],
+  "properties": {
+    "summary": { "type": "string" },
+    "verdict": { "type": "string" }
+  }
+}
+```
+
+Required entries default to `string` when `properties` does not specify a type. Supported types are `string`, `number`, `integer`, `boolean`, `object`, and `array`.
 
 #### `--no-color`
 
@@ -286,6 +321,16 @@ Prompt mode returns:
     },
     "trace_id": "trace-message-1"
   }
+}
+```
+
+Contract mode returns only the validated contract JSON, not the normal Assistant envelope:
+
+```json
+{
+  "decision": "ship",
+  "rationale": "tests pass",
+  "next_actions": ["open PR"]
 }
 ```
 

--- a/docs/commands/extract.mdx
+++ b/docs/commands/extract.mdx
@@ -11,6 +11,7 @@ Extract the readable content of a web page as markdown using Kagi's Extract API.
 
 ```bash
 kagi extract <URL> [--format markdown|json|compact]
+kagi extract --filter
 ```
 
 ## Description
@@ -18,6 +19,8 @@ kagi extract <URL> [--format markdown|json|compact]
 The `kagi extract` command sends one HTTPS URL to Kagi's v1 Extract API and prints the extracted page markdown to stdout by default. It is useful when a search result, article, or documentation page needs full-page text instead of a search snippet.
 
 The command uses JSON mode internally because that is the stable envelope returned by the API, then prints the first page's `markdown` field. Use `--format json` or `--format compact` to print the full response envelope, including retained link metadata when Kagi returns it. If Kagi returns no page markdown, the CLI reports the Extract API error details and trace id when available.
+
+Use `--filter` for pipelines that already have one URL per line. Filter mode ignores the single-URL markdown default and prints one compact JSON record per input line in the same order. Successful records include the Extract API response under `response`. Failed records include an `error` envelope on stdout and the command exits nonzero after all inputs are processed.
 
 ## Authentication
 
@@ -36,6 +39,16 @@ kagi extract "https://example.com/article"
 ```
 
 Only `https://` URLs with a valid host are accepted.
+
+Omit `<URL>` when using `--filter`.
+
+### `--filter`
+
+Read one URL per stdin line and print JSONL records.
+
+```bash
+kagi search "rust release notes" --template '{{url}}' | kagi extract --filter
+```
 
 ### `--format <FORMAT>`
 
@@ -81,6 +94,13 @@ With `--format json`, the command prints the full response envelope:
 }
 ```
 
+With `--filter`, stdout is JSONL:
+
+```jsonl
+{"url":"https://example.com/article","ok":true,"response":{"meta":{"trace":"trace-1","node":"test","ms":12},"data":[{"url":"https://example.com/article","markdown":"# Article title\n\nExtracted page content...","links":[]}]}}
+{"url":"http://example.com/bad","ok":false,"error":{"code":"configuration_error","category":"configuration","retryable":false,"message":"configuration error: extract URL must use the https scheme","suggested_commands":[],"docs_url":"https://kagi.micr.dev/reference/error-reference"}}
+```
+
 ## Examples
 
 ### Save an Article
@@ -101,12 +121,18 @@ kagi extract "https://example.com/article" | sed -n '1,80p'
 kagi extract "https://example.com/article" --format json | jq '.data[0].links'
 ```
 
+### Extract Search Results
+
+```bash
+kagi search "rust async cancellation" --template '{{url}}' | kagi extract --filter > pages.jsonl
+```
+
 ## Exit Codes
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success - markdown extracted |
-| 1 | Error - see stderr |
+| 0 | Success - markdown extracted, or every `--filter` input produced an `ok: true` record |
+| 1 | Error - see stderr; `--filter` may still have written per-input records to stdout |
 
 Common errors:
 

--- a/docs/commands/search.mdx
+++ b/docs/commands/search.mdx
@@ -93,13 +93,16 @@ kagi search --snap reddit "rust async runtime"
 kagi search --snap @map "coffee near london bridge"
 ```
 
-### `--lens <INDEX>`
+### `--lens <INDEX_OR_NAME>`
 
-Scope search to one of your enabled Kagi lenses.
+Scope search to one of your enabled Kagi lenses. Numeric values keep the existing index behavior. Non-numeric values are matched against enabled lens names exactly at runtime, then resolved to the current account-specific numeric position before search.
 
 ```bash
 kagi search --lens 2 "developer documentation"
+kagi search --lens "Rust Docs" "borrow checker examples"
 ```
+
+If a name is missing, disabled, or duplicated, the command fails before search and points you to `kagi lens list` or the numeric index path. Numeric-looking names are treated as numeric indexes.
 
 ### `--region <REGION>`
 
@@ -361,7 +364,10 @@ kagi search --format markdown "rust ownership"
 - `this search option requires KAGI_SESSION_TOKEN` - you used a web-product-only search option without a session token
 - `search --time cannot be combined with --from-date or --to-date` - choose a preset window or a custom date range
 - `search --from-date must use YYYY-MM-DD format` - dates must be zero-padded ISO dates
-- `lens 'foo' must be a numeric index` - lens values are numeric Kagi lens indices
+- `lens named 'foo' was not found` - named lens search matches enabled lens names exactly. Run `kagi lens list`
+- `lens name 'foo' is ambiguous` - multiple lenses have that exact name. Use the numeric index
+- `lens named 'foo' is disabled` - enable it with `kagi lens enable <ID_OR_NAME>` or choose an enabled lens
+- `lens 'foo' must be a numeric index` - internal numeric validation still applies after named lenses are resolved
 
 ## Related Commands
 

--- a/docs/reference/coverage.mdx
+++ b/docs/reference/coverage.mdx
@@ -16,7 +16,7 @@ These endpoints come from Kagi's current OpenAPI contract at `https://kagi.com/a
 | Endpoint | Command | Status |
 |----------|---------|--------|
 | Search API (`POST /api/v1/search`) | `kagi search` | ✅ Implemented for query, limit, and `filters.region/after/before` |
-| Extract API | `kagi extract` | ✅ Implemented |
+| Extract API | `kagi extract` | ✅ Implemented, including stdin URL filter mode |
 
 Current V1 Search optional fields not exposed by this CLI: `workflow`, API response `format`, `lens_id`, inline `lens`, `timeout`, `page`, search-result `extract`, `safe_search`, and explicit personalization rule objects. Subscriber web-product features cover some adjacent workflows, but they are not represented as V1 OpenAPI request fields.
 
@@ -39,12 +39,12 @@ These features use the subscriber web product with `KAGI_SESSION_TOKEN`:
 |---------|---------|--------|
 | Base search | `kagi search` | ✅ Implemented |
 | Snap-prefixed search | `kagi search --snap` | ✅ Implemented |
-| Lens search | `kagi search --lens` | ✅ Implemented |
+| Lens search | `kagi search --lens` | ✅ Implemented for numeric indexes and exact enabled lens names |
 | Filtered search | `kagi search --region/--from-date/--to-date` on V1 API or session path; `--time/--order/...` on session path | ✅ Implemented |
 | Quick Answer | `kagi quick` | ✅ Implemented |
 | Web Summarizer | `kagi summarize --subscriber` | ✅ Implemented |
 | Search result summarize pipeline | `kagi search --follow` | ✅ Implemented |
-| Assistant prompt + thread management | `kagi assistant` | ✅ Implemented |
+| Assistant prompt + thread management | `kagi assistant` | ✅ Implemented, including prompt contracts |
 | Assistant terminal REPL | `kagi assistant repl` | ✅ Implemented |
 | Custom assistant management | `kagi assistant custom` | ✅ Implemented |
 | Ask questions about a page | `kagi ask-page` | ✅ Implemented |
@@ -71,7 +71,7 @@ These require no authentication:
 |---------|-------------|------|--------|
 | `search` | Base Kagi search | API or Session | ✅ |
 | `search --snap` | Snap-prefixed search | API or Session | ✅ |
-| `search --lens` | Lens-aware search | Session | ✅ |
+| `search --lens` | Lens-aware search by numeric index or exact enabled name | Session | ✅ |
 | `search` with filters | Region, time, date, order, verbatim, personalization filters | Session | ✅ |
 | `search --template` | Lightweight result templates | API or Session | ✅ |
 | `search --follow` | Search plus subscriber summaries for top results | Session | ✅ |
@@ -83,7 +83,7 @@ These require no authentication:
 | `summarize` | Public API summarizer | API | ✅ |
 | `summarize --subscriber` | Web summarizer | Session | ✅ |
 | `summarize --filter` | Summarize stdin items as URLs or text | API or Session | ✅ |
-| `extract` | Extract page content as markdown | API | ✅ |
+| `extract` | Extract page content as markdown or stdin URL JSONL records | API | ✅ |
 | `watch` | Search diff monitoring | API or Session | ✅ |
 | `notify` | Webhook notifications for search/news | API, Session, or None | ✅ |
 | `history` | Local history and stats | None | ✅ |
@@ -130,12 +130,14 @@ These require no authentication:
 | `--personalized` / `--no-personalized` | search, batch, assistant | ✅ |
 | `--template` | search, batch | ✅ |
 | `--local-cache` / `--cache-ttl` | search, summarize, quick, fastgpt | ✅ |
+| `--error-format` | global | Implemented |
 
 ### Assistant and Settings Options
 
 | Option | Commands | Status |
 |--------|----------|--------|
 | `--assistant` | assistant | ✅ |
+| `--contract` / `--contract-file` | assistant | Implemented |
 | `--thread-id` | assistant | ✅ |
 | `--model` | assistant, assistant custom | ✅ |
 | `--lens` | assistant, assistant custom | ✅ |
@@ -143,6 +145,7 @@ These require no authentication:
 | `thread list/get/delete/export` | assistant | ✅ |
 | `custom list/get/create/update/delete` | assistant | ✅ |
 | `repl` | assistant | ✅ |
+| `--filter` | extract | Implemented |
 | `list/get/create/update/delete` | lens | ✅ |
 | `enable` / `disable` | lens, redirect | ✅ |
 | `custom list/get/create/update/delete` | bang | ✅ |

--- a/docs/reference/error-reference.mdx
+++ b/docs/reference/error-reference.mdx
@@ -9,7 +9,7 @@ This guide catalogs all error messages from the *kagi* CLI, organized by categor
 
 ## Error Format
 
-Errors follow this pattern:
+Plain text errors follow this pattern:
 
 ```
 Error: {category}: {message}
@@ -29,6 +29,27 @@ Transport errors include the request URL when the HTTP client exposes it:
 
 ```text
 Error: Network error: request to https://kagi.com/api/v1/search timed out after the configured timeout
+```
+
+Automation can request compact JSON stderr instead:
+
+```bash
+kagi --error-format json search "rust"
+KAGI_ERROR_FORMAT=json kagi search "rust"
+```
+
+The JSON error envelope uses stable top-level fields:
+
+```json
+{
+  "code": "missing_credentials",
+  "category": "configuration",
+  "retryable": false,
+  "message": "configuration error: missing credentials: search was not sent...",
+  "required_auth": "KAGI_API_KEY or KAGI_SESSION_TOKEN",
+  "suggested_commands": ["kagi auth status", "kagi auth set --api-key <key>", "kagi auth set --session-token <token>"],
+  "docs_url": "https://kagi.micr.dev/reference/error-reference"
+}
 ```
 
 ## Authentication Errors
@@ -269,22 +290,25 @@ Error: Config: --length requires --subscriber
 kagi summarize --subscriber --url https://example.com --length digest
 ```
 
-### "lens 'abc' must be a numeric index"
+### "lens named 'abc' was not found"
 
 **Message:**
 ```
-configuration error: lens 'abc' must be a numeric index (e.g., '0', '1', '2').
+configuration error: lens named 'abc' was not found. Lens names are matched exactly; run `kagi lens list` to inspect available lenses
 ```
 
-**Meaning:** Lens-aware commands only accept the numeric `l=` value from Kagi's web UI.
+**Meaning:** `kagi search --lens` was given a non-numeric value, but no enabled lens has that exact name.
 
 **Solution:**
 ```bash
-# Search
-kagi search --lens 2 "developer documentation"
+kagi lens list
+kagi search --lens "Exact Lens Name" "developer documentation"
+```
 
-# Quick Answer
-kagi quick --lens 2 "best rust tutorials"
+Use a numeric index when names are duplicated or numeric-looking:
+
+```bash
+kagi search --lens 2 "developer documentation"
 ```
 
 ### "--engine is only supported for the paid public summarizer API"

--- a/docs/reference/output-contract.mdx
+++ b/docs/reference/output-contract.mdx
@@ -11,7 +11,7 @@ This page documents the current CLI output behavior as implemented in the repo.
 
 1. Most commands print pretty-formatted JSON to stdout on success.
 2. `kagi search`, `kagi batch`, `kagi quick`, and `kagi assistant` support alternate output via format flags, including `toon` for token-efficient structured context.
-3. Errors are plain text on stderr and exit with status code `1`.
+3. Errors are plain text on stderr and exit with status code `1` by default. Use global `--error-format json` or `KAGI_ERROR_FORMAT=json` for a structured stderr envelope.
 4. Output shapes differ by command. There is no single universal response envelope.
 
 ## Success Shapes
@@ -119,6 +119,34 @@ Subscriber mode:
 }
 ```
 
+### `kagi extract`
+
+Single-URL extract prints markdown by default, or the full Extract API envelope with `--format json`:
+
+```json
+{
+  "meta": {
+    "trace": "trace-1",
+    "node": "test",
+    "ms": 12
+  },
+  "data": [
+    {
+      "url": "https://example.com/article",
+      "markdown": "# Article\n\nExtracted content.",
+      "links": []
+    }
+  ]
+}
+```
+
+`kagi extract --filter` prints compact JSONL, one record per stdin URL:
+
+```jsonl
+{"url":"https://example.com/article","ok":true,"response":{"meta":{"trace":"trace-1","node":"test","ms":12},"data":[{"url":"https://example.com/article","markdown":"# Article","links":[]}]}}
+{"url":"http://example.com/bad","ok":false,"error":{"code":"configuration_error","category":"configuration","retryable":false,"message":"configuration error: extract URL must use the https scheme","suggested_commands":[],"docs_url":"https://kagi.micr.dev/reference/error-reference"}}
+```
+
 ### `kagi news`
 
 ```json
@@ -165,6 +193,16 @@ Subscriber mode:
 ```
 
 `kagi assistant --stream` writes incremental markdown deltas to stdout and flushes after each update. `kagi assistant --stream --stream-output json` writes the same stream as newline-delimited compact JSON events with an `md_delta` field plus the current `meta`, `thread`, and `message` snapshot.
+
+`kagi assistant --contract <NAME>` and `kagi assistant --contract-file <PATH>` print only the validated contract JSON. Contract mode supports `--format json` and `--format compact`.
+
+```json
+{
+  "decision": "ship",
+  "rationale": "tests pass",
+  "next_actions": ["open PR"]
+}
+```
 
 ### `kagi assistant custom`
 
@@ -436,6 +474,20 @@ Errors are plain text on stderr. Typical examples:
 configuration error: missing credentials: search was not sent. Set KAGI_API_KEY or KAGI_SESSION_TOKEN, or run `kagi auth set --api-key <key>` or `kagi auth set --session-token <token>`
 Auth error: invalid or expired Kagi session token
 Network error: request to Kagi timed out
+```
+
+Opt into JSON errors with global `--error-format json` or `KAGI_ERROR_FORMAT=json`. The envelope is compact JSON on stderr:
+
+```json
+{
+  "code": "missing_credentials",
+  "category": "configuration",
+  "retryable": false,
+  "message": "configuration error: missing credentials: search was not sent...",
+  "required_auth": "KAGI_API_KEY or KAGI_SESSION_TOKEN",
+  "suggested_commands": ["kagi auth status", "kagi auth set --api-key <key>", "kagi auth set --session-token <token>"],
+  "docs_url": "https://kagi.micr.dev/reference/error-reference"
+}
 ```
 
 ## jq Examples

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,15 @@ pub enum AssistantThreadExportFormat {
     Json,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+/// Output format for runtime command failures.
+pub enum ErrorOutputFormat {
+    /// Existing human-readable stderr errors.
+    Text,
+    /// Stable JSON object on stderr for automation.
+    Json,
+}
+
 /// Output format options for search results
 #[derive(Debug, Clone, ValueEnum)]
 /// Output format for search results.
@@ -243,6 +252,10 @@ pub struct Cli {
     /// Use a named profile from the kagi config file instead of the default auth block
     #[arg(long, global = true, value_name = "NAME")]
     pub profile: Option<String>,
+
+    /// Runtime error output format
+    #[arg(long, global = true, value_name = "FORMAT", value_enum)]
+    pub error_format: Option<ErrorOutputFormat>,
 
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -751,12 +764,36 @@ impl SummarizeArgs {
 /// Arguments for the `extract` subcommand.
 pub struct ExtractArgs {
     /// HTTPS URL of the page to extract as markdown
-    #[arg(value_name = "URL")]
-    pub url: String,
+    #[arg(value_name = "URL", required_unless_present = "filter")]
+    pub url: Option<String>,
+
+    /// Read one HTTPS URL per stdin line and print one compact JSON record per input
+    #[arg(long, conflicts_with = "url")]
+    pub filter: bool,
 
     /// Output format
     #[arg(long, value_name = "FORMAT", default_value_t = ExtractOutputFormat::Markdown)]
     pub format: ExtractOutputFormat,
+}
+
+impl ExtractArgs {
+    /// Validates extract arguments.
+    ///
+    /// # Errors
+    /// Returns an error when neither a URL nor `--filter` is provided.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.filter {
+            return Ok(());
+        }
+
+        if self.url.as_deref().map(str::trim).is_none_or(str::is_empty) {
+            return Err(
+                "extract requires a URL, or use --filter to read URLs from stdin".to_string(),
+            );
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Args)]
@@ -889,6 +926,14 @@ pub struct AssistantArgs {
     /// Output format for assistant prompt mode
     #[arg(long, value_name = "FORMAT", default_value_t = AssistantOutputFormat::Json)]
     pub format: AssistantOutputFormat,
+
+    /// Validate the final assistant reply against a built-in JSON contract
+    #[arg(long, value_name = "NAME", conflicts_with_all = ["contract_file", "stream"])]
+    pub contract: Option<String>,
+
+    /// Validate the final assistant reply against a small JSON contract file
+    #[arg(long, value_name = "PATH", conflicts_with_all = ["contract", "stream"])]
+    pub contract_file: Option<PathBuf>,
 
     /// Stream prompt updates as text deltas or newline-delimited JSON
     #[arg(long, conflicts_with = "export")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,9 +42,9 @@ use crate::cli::{
     AssistantSubcommand, AssistantThreadExportFormat, AssistantThreadSubcommand, AuthSetArgs,
     AuthSubcommand, BangSubcommand, Cli, Commands, CompletionCommand, CompletionInstallArgs,
     CompletionShell, CompletionSubcommand, CustomBangSubcommand, EnrichSubcommand,
-    ExtractOutputFormat, HistorySubcommand, McpArgs, NotifyArgs, OutputFormat, SearchArgs,
-    SearchOrder, SearchTime, SitePrefMode, SitePrefSubcommand, SkillsCommand, SkillsSubcommand,
-    TranslateArgs, WatchArgs,
+    ErrorOutputFormat, ExtractOutputFormat, HistorySubcommand, McpArgs, NotifyArgs, OutputFormat,
+    SearchArgs, SearchOrder, SearchTime, SitePrefMode, SitePrefSubcommand, SkillsCommand,
+    SkillsSubcommand, TranslateArgs, WatchArgs,
 };
 use crate::error::KagiError;
 use crate::quick::{execute_quick, format_quick_markdown, format_quick_pretty};
@@ -60,6 +60,7 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::collections::BTreeSet;
 use std::env;
+use std::ffi::OsString;
 use std::fs;
 use std::future::Future;
 use std::io::{self, BufRead, Read, Write};
@@ -88,10 +89,167 @@ struct SearchRequestOptions {
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     init_tracing();
+    let error_format = selected_error_output_format();
     if let Err(error) = run().await {
-        eprintln!("{error}");
+        print_kagi_error(&error, error_format);
         std::process::exit(1);
     }
+}
+
+fn selected_error_output_format() -> ErrorOutputFormat {
+    error_output_format_from_args(env::args_os())
+        .or_else(|| {
+            env::var("KAGI_ERROR_FORMAT")
+                .ok()
+                .and_then(|value| parse_error_output_format(&value))
+        })
+        .unwrap_or(ErrorOutputFormat::Text)
+}
+
+fn error_output_format_from_args<I>(args: I) -> Option<ErrorOutputFormat>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut args = args.into_iter().skip(1);
+    while let Some(arg) = args.next() {
+        let arg = arg.to_string_lossy();
+        if arg == "--" {
+            break;
+        }
+        if let Some(value) = arg.strip_prefix("--error-format=") {
+            return parse_error_output_format(value);
+        }
+        if arg == "--error-format" {
+            return args
+                .next()
+                .and_then(|value| parse_error_output_format(&value.to_string_lossy()));
+        }
+    }
+
+    None
+}
+
+fn parse_error_output_format(value: &str) -> Option<ErrorOutputFormat> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "json" => Some(ErrorOutputFormat::Json),
+        "text" => Some(ErrorOutputFormat::Text),
+        _ => None,
+    }
+}
+
+fn print_kagi_error(error: &KagiError, format: ErrorOutputFormat) {
+    match format {
+        ErrorOutputFormat::Text => eprintln!("{error}"),
+        ErrorOutputFormat::Json => match serde_json::to_string(&error_envelope(error)) {
+            Ok(output) => eprintln!("{output}"),
+            Err(_) => eprintln!("{error}"),
+        },
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorEnvelope {
+    code: &'static str,
+    category: &'static str,
+    retryable: bool,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    required_auth: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    http_status: Option<u16>,
+    suggested_commands: Vec<&'static str>,
+    docs_url: &'static str,
+}
+
+fn error_envelope(error: &KagiError) -> ErrorEnvelope {
+    let (code, category, retryable, detail) = match error {
+        KagiError::Network(message) => ("network_error", "network", true, message.as_str()),
+        KagiError::Auth(message) => ("authentication_error", "auth", false, message.as_str()),
+        KagiError::Parse(message) => ("parse_error", "parse", false, message.as_str()),
+        KagiError::Config(message) if message.starts_with("assistant contract") => {
+            ("contract_error", "contract", false, message.as_str())
+        }
+        KagiError::Config(message) if message.contains("missing credentials") => (
+            "missing_credentials",
+            "configuration",
+            false,
+            message.as_str(),
+        ),
+        KagiError::Config(message) => (
+            "configuration_error",
+            "configuration",
+            false,
+            message.as_str(),
+        ),
+        KagiError::Batch(message) => ("batch_error", "batch", false, message.as_str()),
+    };
+    let required_auth = required_auth_for_message(detail);
+
+    ErrorEnvelope {
+        code,
+        category,
+        retryable,
+        message: error.to_string(),
+        required_auth,
+        http_status: extract_http_status(detail),
+        suggested_commands: suggested_commands_for_error(category, required_auth),
+        docs_url: "https://kagi.micr.dev/reference/error-reference",
+    }
+}
+
+fn required_auth_for_message(message: &str) -> Option<&'static str> {
+    if message.contains("missing credentials") {
+        Some("KAGI_API_KEY or KAGI_SESSION_TOKEN")
+    } else if message.contains("KAGI_API_KEY") {
+        Some("KAGI_API_KEY")
+    } else if message.contains("KAGI_API_TOKEN") {
+        Some("KAGI_API_TOKEN")
+    } else if message.contains("KAGI_SESSION_TOKEN") {
+        Some("KAGI_SESSION_TOKEN")
+    } else {
+        None
+    }
+}
+
+fn suggested_commands_for_error(
+    category: &str,
+    required_auth: Option<&'static str>,
+) -> Vec<&'static str> {
+    match required_auth {
+        Some("KAGI_API_KEY") => vec![
+            "kagi auth status",
+            "kagi auth set --api-key <key>",
+            "kagi auth check",
+        ],
+        Some("KAGI_API_TOKEN") => vec![
+            "kagi auth status",
+            "kagi auth set --api-token <token>",
+            "kagi auth check",
+        ],
+        Some("KAGI_SESSION_TOKEN") => vec![
+            "kagi auth status",
+            "kagi auth set --session-token <token>",
+            "kagi auth check",
+        ],
+        Some("KAGI_API_KEY or KAGI_SESSION_TOKEN") => vec![
+            "kagi auth status",
+            "kagi auth set --api-key <key>",
+            "kagi auth set --session-token <token>",
+        ],
+        _ if category == "auth" => vec!["kagi auth status", "kagi auth check"],
+        _ => Vec::new(),
+    }
+}
+
+fn extract_http_status(message: &str) -> Option<u16> {
+    message.split("HTTP ").nth(1).and_then(|suffix| {
+        suffix
+            .chars()
+            .take_while(|character| character.is_ascii_digit())
+            .collect::<String>()
+            .parse::<u16>()
+            .ok()
+    })
 }
 
 fn init_tracing() {
@@ -153,7 +311,7 @@ async fn run() -> Result<(), KagiError> {
                 return print_news_search(&response, &args.format, !args.no_color);
             }
 
-            let options = SearchRequestOptions {
+            let mut options = SearchRequestOptions {
                 snap: args.snap,
                 lens: args.lens,
                 region: args.region,
@@ -166,6 +324,7 @@ async fn run() -> Result<(), KagiError> {
                 personalized: args.personalized,
                 no_personalized: args.no_personalized,
             };
+            options.lens = resolve_search_lens_option(options.lens, profile.as_deref()).await?;
             let request = build_search_request(args.query, &options);
             let format_str = args.format.to_string();
             if let Some(follow_count) = args.follow {
@@ -261,26 +420,39 @@ async fn run() -> Result<(), KagiError> {
                 print_json(&response)
             }
         }
-        Commands::Extract(args) => match args.format {
-            ExtractOutputFormat::Markdown => {
-                let markdown =
-                    execute_extract_with_available_auth(&args.url, profile.as_deref()).await?;
-                println!("{markdown}");
-                Ok(())
+        Commands::Extract(args) => {
+            args.validate().map_err(KagiError::Config)?;
+
+            if args.filter {
+                return run_extract_filter(profile.as_deref()).await;
             }
-            ExtractOutputFormat::Json => {
-                let response =
-                    execute_extract_response_with_available_auth(&args.url, profile.as_deref())
-                        .await?;
-                print_json(&response)
+
+            let url = args.url.as_deref().ok_or_else(|| {
+                KagiError::Config(
+                    "extract requires a URL, or use --filter to read URLs from stdin".to_string(),
+                )
+            })?;
+            match args.format {
+                ExtractOutputFormat::Markdown => {
+                    let markdown =
+                        execute_extract_with_available_auth(url, profile.as_deref()).await?;
+                    println!("{markdown}");
+                    Ok(())
+                }
+                ExtractOutputFormat::Json => {
+                    let response =
+                        execute_extract_response_with_available_auth(url, profile.as_deref())
+                            .await?;
+                    print_json(&response)
+                }
+                ExtractOutputFormat::Compact => {
+                    let response =
+                        execute_extract_response_with_available_auth(url, profile.as_deref())
+                            .await?;
+                    print_compact_json(&response)
+                }
             }
-            ExtractOutputFormat::Compact => {
-                let response =
-                    execute_extract_response_with_available_auth(&args.url, profile.as_deref())
-                        .await?;
-                print_compact_json(&response)
-            }
-        },
+        }
         Commands::News(args) => {
             args.validate().map_err(KagiError::Config)?;
 
@@ -414,7 +586,17 @@ async fn run() -> Result<(), KagiError> {
                     },
                 }
             } else {
-                let query = read_assistant_prompt_query(args.query)?;
+                let contract = load_assistant_contract(
+                    args.contract.as_deref(),
+                    args.contract_file.as_deref(),
+                )?;
+                if contract.is_some() {
+                    validate_assistant_contract_output_format(args.format.clone())?;
+                }
+                let mut query = read_assistant_prompt_query(args.query)?;
+                if let Some(contract) = contract.as_ref() {
+                    query = contract_prompt_query(&query, contract);
+                }
                 let request = AssistantPromptRequest {
                     query,
                     thread_id: args.thread_id,
@@ -433,7 +615,43 @@ async fn run() -> Result<(), KagiError> {
                         _ => None,
                     },
                 };
-                if args.once {
+                if let Some(contract) = contract.as_ref() {
+                    let response = execute_assistant_prompt_for_args(
+                        &request,
+                        args.once,
+                        args.stream.then_some(args.stream_output),
+                        &token,
+                    )
+                    .await?;
+                    let value = match validate_assistant_contract_response(contract, &response) {
+                        Ok(value) => value,
+                        Err(first_error) => {
+                            let mut repair_request = request.clone();
+                            repair_request.thread_id = Some(response.thread.id.clone());
+                            repair_request.query = contract_repair_query(
+                                contract,
+                                assistant_message_content(&response),
+                                &first_error,
+                            );
+                            let repaired = execute_assistant_prompt_for_args(
+                                &repair_request,
+                                args.once,
+                                None,
+                                &token,
+                            )
+                            .await?;
+                            validate_assistant_contract_response(contract, &repaired).map_err(
+                                |second_error| {
+                                    KagiError::Config(format!(
+                                        "assistant contract '{}' was not satisfied after one repair attempt: {second_error}",
+                                        contract.name
+                                    ))
+                                },
+                            )?
+                        }
+                    };
+                    print_assistant_contract_value(&value, args.format)
+                } else if args.once {
                     let response = execute_once_assistant_prompt(
                         &request,
                         args.stream.then_some(args.stream_output),
@@ -1124,32 +1342,68 @@ fn resolve_session_token(profile: Option<&str>) -> Result<String, KagiError> {
         })
 }
 
+fn resolve_api_key(profile: Option<&str>) -> Result<String, KagiError> {
+    let inventory = load_credential_inventory_for_profile(profile)?;
+    inventory.api_key.map(|credential| credential.value).ok_or_else(|| {
+        KagiError::Config(
+            "extract requires KAGI_API_KEY. Set it in the environment or run `kagi auth set --api-key <key>`"
+                .to_string(),
+        )
+    })
+}
+
 async fn execute_extract_with_available_auth(
     url: &str,
     profile: Option<&str>,
 ) -> Result<String, KagiError> {
-    let inventory = load_credential_inventory_for_profile(profile)?;
-    if let Some(key) = inventory.api_key {
-        return execute_extract(url, &key.value).await;
-    }
-
-    Err(KagiError::Config(
-        "extract requires KAGI_API_KEY. Set it in the environment or run `kagi auth set --api-key <key>`".to_string(),
-    ))
+    let api_key = resolve_api_key(profile)?;
+    execute_extract(url, &api_key).await
 }
 
 async fn execute_extract_response_with_available_auth(
     url: &str,
     profile: Option<&str>,
 ) -> Result<crate::types::ExtractResponse, KagiError> {
-    let inventory = load_credential_inventory_for_profile(profile)?;
-    if let Some(key) = inventory.api_key {
-        return execute_extract_response(url, &key.value).await;
+    let api_key = resolve_api_key(profile)?;
+    execute_extract_response(url, &api_key).await
+}
+
+async fn run_extract_filter(profile: Option<&str>) -> Result<(), KagiError> {
+    let urls = read_stdin_lines()?;
+    if urls.is_empty() {
+        return Err(KagiError::Config(
+            "extract --filter requires at least one stdin URL".to_string(),
+        ));
     }
 
-    Err(KagiError::Config(
-        "extract requires KAGI_API_KEY. Set it in the environment or run `kagi auth set --api-key <key>`".to_string(),
-    ))
+    let api_key = resolve_api_key(profile)?;
+    let mut failure_count = 0usize;
+
+    for url in urls {
+        match execute_extract_response(&url, &api_key).await {
+            Ok(response) => print_compact_json(&serde_json::json!({
+                "url": url,
+                "ok": true,
+                "response": response,
+            }))?,
+            Err(error) => {
+                failure_count += 1;
+                print_compact_json(&serde_json::json!({
+                    "url": url,
+                    "ok": false,
+                    "error": error_envelope(&error),
+                }))?;
+            }
+        }
+    }
+
+    if failure_count > 0 {
+        return Err(KagiError::Batch(format!(
+            "extract --filter completed with {failure_count} failed item(s)"
+        )));
+    }
+
+    Ok(())
 }
 
 fn build_translate_request(args: TranslateArgs) -> Result<TranslateCommandRequest, KagiError> {
@@ -1307,6 +1561,54 @@ fn search_auth_requirement(request: &search::SearchRequest) -> SearchAuthRequire
     }
 }
 
+async fn resolve_search_lens_option(
+    lens: Option<String>,
+    profile: Option<&str>,
+) -> Result<Option<String>, KagiError> {
+    let Some(lens) = lens else {
+        return Ok(None);
+    };
+    let lens = lens.trim().to_string();
+    if lens.is_empty() || lens.parse::<u32>().is_ok() {
+        return Ok(Some(lens));
+    }
+
+    let token = resolve_session_token(profile)?;
+    let lenses = execute_lens_list(&token).await?;
+    let matches = lenses
+        .iter()
+        .filter(|candidate| candidate.name == lens)
+        .collect::<Vec<_>>();
+
+    let [selected] = matches.as_slice() else {
+        if matches.is_empty() {
+            return Err(KagiError::Config(format!(
+                "lens named '{lens}' was not found. Lens names are matched exactly; run `kagi lens list` to inspect available lenses"
+            )));
+        }
+
+        return Err(KagiError::Config(format!(
+            "lens name '{lens}' is ambiguous because multiple lenses have that exact name. Use the numeric lens index instead"
+        )));
+    };
+
+    if !selected.enabled {
+        return Err(KagiError::Config(format!(
+            "lens named '{lens}' is disabled. Enable it with `kagi lens enable {}` or choose an enabled lens",
+            selected.id
+        )));
+    }
+
+    selected
+        .position
+        .map(|position| Some(position.to_string()))
+        .ok_or_else(|| {
+            KagiError::Config(format!(
+                "lens named '{lens}' is enabled but has no active search position. Disable and re-enable it, then retry"
+            ))
+        })
+}
+
 fn print_json<T: serde::Serialize>(value: &T) -> Result<(), KagiError> {
     let output = serde_json::to_string_pretty(value)
         .map_err(|error| KagiError::Parse(format!("failed to serialize JSON output: {error}")))?;
@@ -1376,6 +1678,21 @@ fn temporary_assistant_name() -> String {
     format!("kagi-cli-once-{millis}-{}", std::process::id())
 }
 
+async fn execute_assistant_prompt_for_args(
+    request: &AssistantPromptRequest,
+    once: bool,
+    stream_output: Option<AssistantStreamOutput>,
+    token: &str,
+) -> Result<crate::types::AssistantPromptResponse, KagiError> {
+    if once {
+        execute_once_assistant_prompt(request, stream_output, token).await
+    } else if let Some(stream_output) = stream_output {
+        execute_streaming_assistant_prompt(request, token, stream_output).await
+    } else {
+        execute_assistant_prompt(request, token).await
+    }
+}
+
 async fn execute_streaming_assistant_prompt(
     request: &AssistantPromptRequest,
     token: &str,
@@ -1420,6 +1737,297 @@ fn print_toon<T: serde::Serialize>(value: &T) -> Result<(), KagiError> {
         .map_err(|error| KagiError::Parse(format!("failed to serialize TOON output: {error}")))?;
     println!("{}", toon::encode(&value, None));
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct AssistantContractSpec {
+    name: String,
+    fields: Vec<AssistantContractField>,
+}
+
+#[derive(Debug, Clone)]
+struct AssistantContractField {
+    name: String,
+    kind: AssistantContractFieldKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AssistantContractFieldKind {
+    String,
+    Number,
+    Boolean,
+    Object,
+    Array,
+    StringArray,
+}
+
+fn load_assistant_contract(
+    builtin: Option<&str>,
+    file: Option<&Path>,
+) -> Result<Option<AssistantContractSpec>, KagiError> {
+    match (builtin, file) {
+        (Some(name), None) => builtin_assistant_contract(name).map(Some),
+        (None, Some(path)) => load_assistant_contract_file(path).map(Some),
+        (None, None) => Ok(None),
+        (Some(_), Some(_)) => Err(KagiError::Config(
+            "assistant contract mode accepts either --contract or --contract-file, not both"
+                .to_string(),
+        )),
+    }
+}
+
+fn builtin_assistant_contract(name: &str) -> Result<AssistantContractSpec, KagiError> {
+    let normalized = name.trim().to_ascii_lowercase();
+    let fields = match normalized.as_str() {
+        "decision" => vec![
+            contract_field("decision", AssistantContractFieldKind::String),
+            contract_field("rationale", AssistantContractFieldKind::String),
+            contract_field("next_actions", AssistantContractFieldKind::StringArray),
+        ],
+        "checklist" => vec![contract_field(
+            "items",
+            AssistantContractFieldKind::StringArray,
+        )],
+        "plan" => vec![contract_field(
+            "steps",
+            AssistantContractFieldKind::StringArray,
+        )],
+        _ => {
+            return Err(KagiError::Config(format!(
+                "unknown assistant contract '{name}'. Supported contracts: decision, checklist, plan"
+            )));
+        }
+    };
+
+    Ok(AssistantContractSpec {
+        name: normalized,
+        fields,
+    })
+}
+
+fn load_assistant_contract_file(path: &Path) -> Result<AssistantContractSpec, KagiError> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        KagiError::Config(format!(
+            "failed to read assistant contract file '{}': {error}",
+            path.display()
+        ))
+    })?;
+    let value: Value = serde_json::from_str(&raw).map_err(|error| {
+        KagiError::Config(format!(
+            "assistant contract file '{}' must be valid JSON: {error}",
+            path.display()
+        ))
+    })?;
+    if value
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| kind != "object")
+    {
+        return Err(KagiError::Config(
+            "assistant contract file only supports top-level type \"object\"".to_string(),
+        ));
+    }
+
+    let required = value
+        .get("required")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            KagiError::Config("assistant contract file must include a required array".to_string())
+        })?;
+    if required.is_empty() {
+        return Err(KagiError::Config(
+            "assistant contract file required array cannot be empty".to_string(),
+        ));
+    }
+
+    let mut fields = Vec::new();
+    for item in required {
+        let name = item
+            .as_str()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| {
+                KagiError::Config(
+                    "assistant contract file required entries must be non-empty strings"
+                        .to_string(),
+                )
+            })?;
+        fields.push(contract_field(
+            name,
+            contract_file_field_kind(&value, name)?,
+        ));
+    }
+
+    let name = value
+        .get("title")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("name").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            path.file_stem()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "contract-file".to_string());
+
+    Ok(AssistantContractSpec { name, fields })
+}
+
+fn contract_file_field_kind(
+    contract: &Value,
+    field_name: &str,
+) -> Result<AssistantContractFieldKind, KagiError> {
+    let Some(kind) = contract
+        .get("properties")
+        .and_then(Value::as_object)
+        .and_then(|properties| properties.get(field_name))
+        .and_then(|property| property.get("type"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(AssistantContractFieldKind::String);
+    };
+
+    match kind {
+        "string" => Ok(AssistantContractFieldKind::String),
+        "number" | "integer" => Ok(AssistantContractFieldKind::Number),
+        "boolean" => Ok(AssistantContractFieldKind::Boolean),
+        "object" => Ok(AssistantContractFieldKind::Object),
+        "array" => Ok(AssistantContractFieldKind::Array),
+        _ => Err(KagiError::Config(format!(
+            "assistant contract file property '{field_name}' uses unsupported type '{kind}'"
+        ))),
+    }
+}
+
+fn contract_field(name: &str, kind: AssistantContractFieldKind) -> AssistantContractField {
+    AssistantContractField {
+        name: name.to_string(),
+        kind,
+    }
+}
+
+fn validate_assistant_contract_output_format(
+    format: AssistantOutputFormat,
+) -> Result<(), KagiError> {
+    if matches!(
+        format,
+        AssistantOutputFormat::Json | AssistantOutputFormat::Compact
+    ) {
+        return Ok(());
+    }
+
+    Err(KagiError::Config(
+        "assistant contract mode only supports --format json or --format compact because the validated output is JSON".to_string(),
+    ))
+}
+
+fn contract_prompt_query(query: &str, contract: &AssistantContractSpec) -> String {
+    format!(
+        "{query}\n\n{}",
+        assistant_contract_instruction(contract, "Return only a valid JSON object")
+    )
+}
+
+fn contract_repair_query(
+    contract: &AssistantContractSpec,
+    previous_reply: &str,
+    validation_error: &str,
+) -> String {
+    format!(
+        "Your previous answer did not satisfy the assistant contract '{}': {validation_error}\n\nPrevious answer:\n{previous_reply}\n\n{}",
+        contract.name,
+        assistant_contract_instruction(
+            contract,
+            "Repair the answer and return only the valid JSON object"
+        )
+    )
+}
+
+fn assistant_contract_instruction(contract: &AssistantContractSpec, lead: &str) -> String {
+    let fields = contract
+        .fields
+        .iter()
+        .map(|field| format!("- {}: {}", field.name, field.kind.description()))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "Assistant contract: {lead}. Do not include markdown fences, prose outside JSON, comments, or trailing commas.\nRequired top-level fields:\n{fields}"
+    )
+}
+
+fn validate_assistant_contract_response(
+    contract: &AssistantContractSpec,
+    response: &crate::types::AssistantPromptResponse,
+) -> Result<Value, String> {
+    let content = assistant_message_content(response);
+    let value = serde_json::from_str::<Value>(content)
+        .map_err(|error| format!("assistant reply was not valid JSON: {error}"))?;
+    validate_assistant_contract_value(contract, &value)?;
+    Ok(value)
+}
+
+fn validate_assistant_contract_value(
+    contract: &AssistantContractSpec,
+    value: &Value,
+) -> Result<(), String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "assistant reply must be a JSON object".to_string())?;
+
+    for field in &contract.fields {
+        let field_value = object
+            .get(&field.name)
+            .ok_or_else(|| format!("missing required key '{}'", field.name))?;
+        field.kind.validate(&field.name, field_value)?;
+    }
+
+    Ok(())
+}
+
+fn print_assistant_contract_value(
+    value: &Value,
+    format: AssistantOutputFormat,
+) -> Result<(), KagiError> {
+    match format {
+        AssistantOutputFormat::Compact => print_compact_json(value),
+        AssistantOutputFormat::Json => print_json(value),
+        _ => validate_assistant_contract_output_format(format),
+    }
+}
+
+impl AssistantContractFieldKind {
+    const fn description(self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Number => "number",
+            Self::Boolean => "boolean",
+            Self::Object => "object",
+            Self::Array => "array",
+            Self::StringArray => "array of strings",
+        }
+    }
+
+    fn validate(self, field_name: &str, value: &Value) -> Result<(), String> {
+        let valid = match self {
+            Self::String => value.as_str().is_some_and(|text| !text.trim().is_empty()),
+            Self::Number => value.is_number(),
+            Self::Boolean => value.is_boolean(),
+            Self::Object => value.is_object(),
+            Self::Array => value.is_array(),
+            Self::StringArray => value
+                .as_array()
+                .is_some_and(|items| items.iter().all(Value::is_string)),
+        };
+
+        if valid {
+            Ok(())
+        } else {
+            Err(format!("key '{field_name}' must be {}", self.description()))
+        }
+    }
 }
 
 async fn cached_json<T, K, Fut, F>(

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -22,6 +22,7 @@ fn run_kagi(args: &[&str], envs: &[(&str, &str)], cwd: &Path) -> Output {
         "KAGI_BASE_URL",
         "KAGI_NEWS_BASE_URL",
         "KAGI_TRANSLATE_BASE_URL",
+        "KAGI_ERROR_FORMAT",
         "KAGI_CACHE_DIR",
         "XDG_CONFIG_HOME",
         "XDG_DATA_HOME",
@@ -55,6 +56,7 @@ fn run_kagi_with_stdin(args: &[&str], stdin: &str, envs: &[(&str, &str)], cwd: &
         "KAGI_BASE_URL",
         "KAGI_NEWS_BASE_URL",
         "KAGI_TRANSLATE_BASE_URL",
+        "KAGI_ERROR_FORMAT",
         "KAGI_CACHE_DIR",
         "XDG_CONFIG_HOME",
         "XDG_DATA_HOME",
@@ -154,6 +156,56 @@ fn default_failure_stderr_has_single_user_facing_error() {
         1,
         "expected one user-facing missing credentials error, got:\n{stderr}"
     );
+}
+
+#[test]
+fn json_error_format_prints_structured_stderr() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let output = run_kagi(
+        &["--error-format", "json", "search", "rust"],
+        &[],
+        tempdir.path(),
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected search without auth to fail"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "expected no stdout, got:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let envelope: Value =
+        serde_json::from_slice(&output.stderr).expect("stderr should be a JSON error envelope");
+    assert_eq!(envelope["code"], "missing_credentials");
+    assert_eq!(envelope["category"], "configuration");
+    assert_eq!(envelope["retryable"], false);
+    assert_eq!(
+        envelope["required_auth"],
+        "KAGI_API_KEY or KAGI_SESSION_TOKEN"
+    );
+    assert!(
+        envelope["suggested_commands"]
+            .as_array()
+            .expect("suggested_commands should be an array")
+            .iter()
+            .any(|command| command == "kagi auth status")
+    );
+
+    let env_tempdir = TempDir::new().expect("tempdir");
+    let env_output = run_kagi(
+        &["search", "rust"],
+        &[("KAGI_ERROR_FORMAT", "json")],
+        env_tempdir.path(),
+    );
+    assert!(
+        !env_output.status.success(),
+        "expected search without auth to fail"
+    );
+    let env_envelope: Value = serde_json::from_slice(&env_output.stderr)
+        .expect("env-selected stderr should be a JSON error envelope");
+    assert_eq!(env_envelope["code"], "missing_credentials");
 }
 
 #[test]
@@ -358,6 +410,31 @@ fn assistant_list_html() -> &'static str {
     "#
 }
 
+fn assistant_prompt_stream_body(markdown: &str) -> String {
+    let hello = json!({ "v": "test", "trace": "trace-contract" });
+    let thread = json!({
+        "id": "thread-contract",
+        "title": "Contract",
+        "ack": "2026-06-07T00:00:00Z",
+        "created_at": "2026-06-07T00:00:00Z",
+        "saved": false,
+        "shared": false,
+        "branch_id": "00000000-0000-4000-0000-000000000000",
+        "folder_ids": []
+    });
+    let message = json!({
+        "id": "msg-contract",
+        "thread_id": "thread-contract",
+        "created_at": "2026-06-07T00:00:00Z",
+        "state": "done",
+        "prompt": "contract prompt",
+        "md": markdown,
+        "documents": []
+    });
+
+    format!("hi:{hello}\0\nthread.json:{thread}\0\nnew_message.json:{message}\0\n")
+}
+
 fn search_payload(title: &str, url: &str, snippet: &str) -> Value {
     json!({
         "meta": api_meta(),
@@ -381,6 +458,19 @@ fn search_html_fixture() -> &'static str {
         <div class="__sri-desc">Served by session fallback.</div>
       </div>
     </body></html>
+    "#
+}
+
+fn lens_settings_html_fixture() -> &'static str {
+    r#"
+    <form class="__lens_item" action="/lenses/move" method="POST">
+      <input type="hidden" name="lens_id" value="22524">
+      <input type="hidden" name="active_index" value="2">
+      <a class="lens_title" href="/settings/update_lens?id=22524"><div>Rust Docs</div></a>
+      <div class="lens_edit_lens">
+        <a aria-label="Edit lens" href="/settings/update_lens?id=22524">Edit</a>
+      </div>
+    </form>
     "#
 }
 
@@ -720,6 +810,50 @@ fn search_command_falls_back_to_session_when_api_is_rate_limited() {
     assert_success(&output);
     api_search.assert_calls(1);
     session_search.assert_calls(1);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["data"][0]["title"], "Session Result");
+}
+
+#[test]
+fn search_lens_name_resolves_to_current_position() {
+    let server = MockServer::start();
+    let lenses = server.mock(|when, then| {
+        when.method(GET)
+            .path("/html/settings/lenses")
+            .header("cookie", "kagi_session=test-session");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body(lens_settings_html_fixture());
+    });
+    let search = server.mock(|when, then| {
+        when.method(GET)
+            .path("/html/search")
+            .query_param("q", "rust ownership")
+            .query_param("l", "2")
+            .header("cookie", "kagi_session=test-session");
+        then.status(200)
+            .header("content-type", "text/html")
+            .body(search_html_fixture());
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = session_env(&server);
+    let output = run_kagi(
+        &[
+            "search",
+            "rust ownership",
+            "--lens",
+            "Rust Docs",
+            "--format",
+            "json",
+        ],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    lenses.assert_calls(1);
+    search.assert_calls(1);
     let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
     assert_eq!(body["data"][0]["title"], "Session Result");
 }
@@ -1114,6 +1248,71 @@ fn extract_command_requires_api_key_with_session_only_auth() {
     );
 }
 
+#[test]
+fn extract_filter_prints_ordered_jsonl_records() {
+    let server = MockServer::start();
+    let extract = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/v1/extract")
+            .header("authorization", "Bearer test-api-key")
+            .json_body(json!({
+                "pages": [
+                    {
+                        "url": "https://example.com/one"
+                    }
+                ],
+                "format": "json"
+            }));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "meta": {
+                    "trace": "trace-1",
+                    "node": "test",
+                    "ms": 12
+                },
+                "data": [
+                    {
+                        "url": "https://example.com/one",
+                        "markdown": "# One"
+                    }
+                ]
+            }));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = test_env(&server);
+    let output = run_kagi_with_stdin(
+        &["extract", "--filter"],
+        "https://example.com/one\nhttp://example.com/two\n",
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected nonzero exit when one filter item fails"
+    );
+    extract.assert_calls(1);
+    let records = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("JSONL record should parse"))
+        .collect::<Vec<_>>();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["url"], "https://example.com/one");
+    assert_eq!(records[0]["ok"], true);
+    assert_eq!(records[0]["response"]["data"][0]["markdown"], "# One");
+    assert_eq!(records[1]["url"], "http://example.com/two");
+    assert_eq!(records[1]["ok"], false);
+    assert_eq!(records[1]["error"]["code"], "configuration_error");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("extract --filter completed with 1 failed item"),
+        "expected aggregate failure on stderr, got:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn news_search_html_fixture() -> &'static str {
     r#"<html><body>
         <div class="newsResultItem _0_SRI">
@@ -1470,6 +1669,104 @@ fn assistant_stream_can_print_ndjson_updates() {
     assert_eq!(lines[0]["md_delta"], "Hel");
     assert_eq!(lines[1]["md_delta"], "lo");
     assert_eq!(lines[1]["message"]["state"], "done");
+}
+
+#[test]
+fn assistant_contract_decision_prints_validated_json() {
+    let server = MockServer::start();
+    let prompt = server.mock(|when, then| {
+        when.method(POST)
+            .path("/assistant/prompt")
+            .header("cookie", "kagi_session=test-session")
+            .header("accept", "application/vnd.kagi.stream")
+            .header("content-type", "application/json")
+            .body_includes("Assistant contract")
+            .body_includes("decision")
+            .body_includes("next_actions");
+        then.status(200)
+            .header("content-type", "application/vnd.kagi.stream")
+            .body(assistant_prompt_stream_body(
+                r#"{"decision":"ship","rationale":"tests pass","next_actions":["open PR"]}"#,
+            ));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = session_env(&server);
+    let output = run_kagi(
+        &["assistant", "--contract", "decision", "Should I ship?"],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    prompt.assert_calls(1);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["decision"], "ship");
+    assert_eq!(body["rationale"], "tests pass");
+    assert_eq!(body["next_actions"], json!(["open PR"]));
+    assert!(
+        body.get("message").is_none(),
+        "contract mode should print the contract JSON only"
+    );
+}
+
+#[test]
+fn assistant_contract_file_rejects_missing_required_key() {
+    let server = MockServer::start();
+    let prompt = server.mock(|when, then| {
+        when.method(POST)
+            .path("/assistant/prompt")
+            .header("cookie", "kagi_session=test-session")
+            .header("accept", "application/vnd.kagi.stream")
+            .header("content-type", "application/json")
+            .body_includes("Assistant contract")
+            .body_includes("verdict");
+        then.status(200)
+            .header("content-type", "application/vnd.kagi.stream")
+            .body(assistant_prompt_stream_body(r#"{"summary":"not enough"}"#));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let contract_path = tempdir.path().join("verdict-contract.json");
+    fs::write(
+        &contract_path,
+        r#"{
+          "type": "object",
+          "required": ["summary", "verdict"],
+          "properties": {
+            "summary": { "type": "string" },
+            "verdict": { "type": "string" }
+          }
+        }"#,
+    )
+    .expect("contract file should write");
+    let env = session_env(&server);
+    let contract_path_string = contract_path.to_string_lossy().to_string();
+    let output = run_kagi(
+        &[
+            "assistant",
+            "--contract-file",
+            &contract_path_string,
+            "Summarize the release state",
+        ],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected invalid contract output to fail"
+    );
+    prompt.assert_calls(2);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("assistant contract"),
+        "expected contract error, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("missing required key 'verdict'"),
+        "expected missing key detail, got:\n{stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
**Summary**
- Add assistant prompt contracts with built-in and file-backed validation plus one repair attempt
- Add opt-in JSON error envelopes via `--error-format json` and `KAGI_ERROR_FORMAT=json`
- Resolve `kagi search --lens` exact enabled lens names to the current numeric position
- Add `kagi extract --filter` JSONL mode for stdin URL pipelines
- Update `quinn-proto` in `Cargo.lock` to satisfy the current RustSec audit gate

**Verification**
- `facts check`
- `cargo audit`
- `make check`
- GitHub checks on PR #128: `rust`, `coverage`, and `cargo-audit` passed; Mintlify deployment skipped