### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,7 @@ jobs:
 
           if [ -z "${MINTLIFY_DEPLOY_COOKIE:-}" ]; then
             echo "MINTLIFY_DEPLOY_COOKIE is not configured; skipping Mintlify deployment trigger."
+            echo "status=skipped" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -227,6 +228,7 @@ jobs:
             -H "referer: https://app.mintlify.com/kagi-cli/kagi-cli" \
             -H "cookie: ${MINTLIFY_DEPLOY_COOKIE}" \
             https://app.mintlify.com/api/deployment/update/kagi-cli
+          echo "status=triggered" >> "$GITHUB_OUTPUT"
 
       - name: Sync Homebrew tap and Scoop bucket
         id: sync_package_indexes
@@ -238,6 +240,7 @@ jobs:
 
           if [ -z "${REPO_SYNC_TOKEN:-}" ]; then
             echo "REPO_SYNC_TOKEN is not configured; skipping Homebrew/Scoop sync."
+            echo "status=skipped" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -373,6 +376,7 @@ jobs:
             git -C "$BUCKET_DIR" commit -m "chore: update kagi manifest for ${RELEASE_TAG}"
             push_with_token "$BUCKET_DIR"
           fi
+          echo "status=synced" >> "$GITHUB_OUTPUT"
 
       - name: Sync AUR package
         id: sync_aur_package
@@ -384,6 +388,7 @@ jobs:
 
           if [ -z "${AUR_SSH_PRIVATE_KEY:-}" ]; then
             echo "AUR_SSH_PRIVATE_KEY is not configured; skipping AUR sync."
+            echo "status=skipped" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -505,18 +510,19 @@ jobs:
             git -C "$AUR_DIR" commit -m "chore: update kagi-cli for ${RELEASE_TAG}"
             git -C "$AUR_DIR" push origin master
           fi
+          echo "status=synced" >> "$GITHUB_OUTPUT"
 
       - name: Report package index sync warning
-        if: steps.sync_package_indexes.outcome == 'failure'
+        if: steps.sync_package_indexes.outcome == 'failure' || steps.sync_package_indexes.outputs.status == 'skipped'
         run: |
-          echo "::warning title=Package index sync failed::GitHub release assets were published, but Homebrew/Scoop sync did not complete. Check the release job logs."
+          echo "::warning title=Package index sync incomplete::GitHub release assets were published, but Homebrew/Scoop sync did not complete. Configure REPO_SYNC_TOKEN or update the package indexes manually."
 
       - name: Report AUR package sync warning
-        if: steps.sync_aur_package.outcome == 'failure'
+        if: steps.sync_aur_package.outcome == 'failure' || steps.sync_aur_package.outputs.status == 'skipped'
         run: |
-          echo "::warning title=AUR package sync failed::GitHub release assets were published, but the AUR package was not updated. Check the release job logs."
+          echo "::warning title=AUR package sync incomplete::GitHub release assets were published, but the AUR package was not updated. Configure AUR_SSH_PRIVATE_KEY or update the AUR package manually."
 
       - name: Report Mintlify deployment warning
-        if: steps.trigger_mintlify_docs.outcome == 'failure'
+        if: steps.trigger_mintlify_docs.outcome == 'failure' || steps.trigger_mintlify_docs.outputs.status == 'skipped'
         run: |
-          echo "::warning title=Mintlify deployment trigger failed::GitHub release assets were published, but the private Mintlify deployment endpoint did not accept the configured cookie. Rotate MINTLIFY_DEPLOY_COOKIE or trigger the deployment from the Mintlify dashboard."
+          echo "::warning title=Mintlify deployment incomplete::GitHub release assets were published, but docs deployment was not confirmed. Configure or rotate MINTLIFY_DEPLOY_COOKIE, or trigger the deployment from the Mintlify dashboard."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+## [0.12.0]
+
+### Added
+
+- `kagi assistant` now supports built-in and file-backed JSON contracts for prompt responses, validates the final Assistant output before printing it, and makes one repair attempt when the model returns invalid JSON.
+- CLI failures can opt into structured JSON error envelopes with `--error-format json` or `KAGI_ERROR_FORMAT=json`.
+- `kagi search --lens` now accepts exact enabled lens names as well as numeric lens positions.
+- `kagi extract --filter` now reads HTTPS URLs from stdin and emits ordered JSONL records for pipeline-friendly batch extraction.
+
+### Changed
+
+- Release automation now emits explicit warnings when optional Homebrew, Scoop, AUR, or Mintlify sync credentials are missing or stale.
+
+### Fixed
+
+- Updated `quinn-proto` to clear the current RustSec `cargo audit` gate.
+
 ## [0.11.0]
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "kagi"
-version = "0.10.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kagi"
-version = "0.10.0"
+version = "0.12.0"
 edition = "2024"
 description = "Agent-native CLI for Kagi subscribers with JSON-first search output"
 license = "MIT"

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -256,4 +256,4 @@ The *kagi* CLI is open source and welcomes contributions. See the [Development G
 
 ---
 
-*Last updated: June 2026 | kagi CLI v0.10.0*
+*Last updated: June 2026 | kagi CLI v0.12.0*

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -17,6 +17,7 @@ Ship one version across the Rust CLI, GitHub release assets, npm wrapper, Homebr
    - `REPO_SYNC_TOKEN` GitHub Actions secret for `Microck/homebrew-kagi` and `Microck/scoop-kagi`
    - `AUR_SSH_PRIVATE_KEY` GitHub Actions secret for `ssh://aur@aur.archlinux.org/kagi-cli.git`
    - `MINTLIFY_DEPLOY_COOKIE` GitHub Actions secret for the private Mintlify deployment trigger
+   Missing or stale optional sync credentials do not block GitHub release asset publication, but the release workflow emits explicit warnings and the affected channel must be recovered manually.
 5. Confirm `CHANGELOG.md` has a complete user-facing entry ready to publish. The release workflow extracts notes from the `## [X.Y.Z]` section, so the heading must exist before the tag is pushed.
 
 ## Update release metadata
@@ -72,6 +73,7 @@ git push origin vX.Y.Z
 - calls Mintlify's private deployment update endpoint when `MINTLIFY_DEPLOY_COOKIE` is configured
 - syncs `Microck/homebrew-kagi` and `Microck/scoop-kagi`
 - syncs the `kagi-cli` AUR package when `AUR_SSH_PRIVATE_KEY` is configured
+- warns when optional package-index, AUR, or Mintlify sync work is skipped or fails after GitHub release publication
 
 `.github/workflows/npm-publish.yml` runs after a successful `Release` workflow and publishes `npm/package.json` to npm when `NPM_PUBLISH_ENABLED=true`.
 
@@ -103,7 +105,7 @@ Verify all public release surfaces after the workflows finish:
 7. Mintlify docs
    - confirm `https://kagi.micr.dev` reflects the committed docs changes from `docs/`
    - if the site still shows old content, inspect the `Trigger Mintlify docs deployment` release step
-   - if Mintlify rejected the private deployment trigger, rotate `MINTLIFY_DEPLOY_COOKIE` or trigger the deployment from the Mintlify dashboard
+   - if Mintlify rejected the private deployment trigger or the release emitted a Mintlify warning, rotate `MINTLIFY_DEPLOY_COOKIE` or trigger the deployment from the Mintlify dashboard
    - verify the changed command, guide, or reference pages render correctly
 8. Installers and scripts
    - `scripts/install.sh` and `scripts/install.ps1` resolve the latest GitHub release dynamically, so they need no per-release version bump
@@ -175,6 +177,8 @@ Mintlify docs are source-controlled under `docs/`. Automatic GitHub App deployme
 Configure `MINTLIFY_DEPLOY_COOKIE` as a GitHub Actions secret containing the complete `Cookie` header value from an authenticated Mintlify dashboard session that can deploy `kagi-cli`. Do not commit this value, paste it into logs, or store it in repo files.
 
 This uses a private dashboard endpoint, not a stable public API. If the cookie expires, Mintlify changes the endpoint, or Cloudflare rejects the request, the release workflow emits a warning and continues. Rotate the secret or trigger the deployment from the Mintlify dashboard.
+
+The public docs site can still return HTTP 200 while serving an old deployment. Compare visible docs content or response metadata such as `last-modified` against the release changes before treating Mintlify as complete.
 
 ### Cargo
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagi-cli",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "description": "Node wrapper that installs the native kagi CLI binary",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
**Summary**
- Bump Rust CLI and npm wrapper metadata to `0.12.0`
- Add `CHANGELOG.md` notes for the assistant contract, JSON error, named lens, and extract filter features
- Update docs footer and release runbook details
- Make release workflow warnings explicit when optional package/docs sync credentials are missing

**Verification**
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -q --locked`
- `(cd npm && npm pack --dry-run)`