### PR TITLE
fix(assistant): add thread.html fallback for thread_open parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+## [0.14.1]
+
+### Fixed
+
+- Assistant `thread_open` no longer fails on new threads after Kagi's backend URL change. When the `thread.json` stream frame is absent, the parser now falls back to the `thread.html` frame to extract thread metadata. The error message for missing thread frames now lists which stream tags were received to aid future debugging.
+
 ## [0.14.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "kagi"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kagi"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 description = "Agent-native CLI for Kagi subscribers with JSON-first search output"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagi-cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Node wrapper that installs the native kagi CLI binary",
   "license": "MIT",
   "repository": {

--- a/src/api.rs
+++ b/src/api.rs
@@ -3869,8 +3869,8 @@ fn parse_assistant_thread_open_stream(
 
 fn parse_assistant_thread_open_html(html: &str) -> Result<AssistantThread, KagiError> {
     let document = Html::parse_fragment(html);
-    let thread_selector = selector(".thread")?;
-    let title_selector = selector(".title")?;
+    let thread_selector = Selector::parse(".thread").expect("valid CSS selector");
+    let title_selector = Selector::parse(".title").expect("valid CSS selector");
 
     let element = document
         .select(&thread_selector)
@@ -3890,6 +3890,11 @@ fn parse_assistant_thread_open_html(html: &str) -> Result<AssistantThread, KagiE
         .filter(|value| !value.is_empty())
         .ok_or_else(|| KagiError::Parse("assistant thread html missing title".to_string()))?;
 
+    let folder_ids = serde_json::from_str::<Vec<String>>(
+        element.value().attr("data-folders").unwrap_or("[]"),
+    )
+    .unwrap_or_default();
+
     Ok(AssistantThread {
         id,
         title,
@@ -3905,7 +3910,7 @@ fn parse_assistant_thread_open_html(html: &str) -> Result<AssistantThread, KagiE
             .attr("data-public")
             .is_some_and(|value| value == "true"),
         branch_id: String::new(),
-        folder_ids: Vec::new(),
+        folder_ids,
     })
 }
 
@@ -3915,11 +3920,6 @@ fn format_received_frame_tags(tags: &[String]) -> String {
     } else {
         tags.join(", ")
     }
-}
-
-fn selector(value: &str) -> Result<Selector, KagiError> {
-    Selector::parse(value)
-        .map_err(|error| KagiError::Parse(format!("failed to parse selector `{value}`: {error:?}")))
 }
 
 fn parse_assistant_thread_list_stream(
@@ -5862,6 +5862,7 @@ mod tests {
             "    data-saved=\"false\"\n",
             "    data-public=\"false\"\n",
             "    data-tags=\"[]\"\n",
+            "    data-folders='[\"folder-1\", \"folder-2\"]'\n",
             "    data-snippet=\"none\"\n",
             "    >\n",
             "  <i title=\"Temporary\">temp</i>\n",
@@ -5883,7 +5884,7 @@ mod tests {
         assert!(parsed.thread.created_at.is_empty());
         assert!(parsed.thread.expires_at.is_empty());
         assert!(parsed.thread.branch_id.is_empty());
-        assert!(parsed.thread.folder_ids.is_empty());
+        assert_eq!(parsed.thread.folder_ids, vec!["folder-1", "folder-2"]);
         assert_eq!(parsed.messages.len(), 1);
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use futures_util::StreamExt;
 use reqwest::multipart;
 use reqwest::{Client, StatusCode, Url, header};
-use scraper::Html;
+use scraper::{Html, Selector};
 use serde::Deserialize;
 #[cfg(test)]
 use serde::Serialize;
@@ -3780,12 +3780,15 @@ fn parse_assistant_thread_open_stream(
     let mut meta = AssistantMeta::default();
     let mut folders = Vec::new();
     let mut thread = None;
+    let mut thread_html = None;
     let mut messages = None;
+    let mut received_tags = Vec::new();
 
     for frame in body.split("\0\n").filter(|frame| !frame.trim().is_empty()) {
         let Some((tag, payload)) = frame.split_once(':') else {
             continue;
         };
+        received_tags.push(tag.to_string());
 
         match tag {
             "hi" => {
@@ -3806,6 +3809,9 @@ fn parse_assistant_thread_open_stream(
                         KagiError::Parse(format!("failed to parse assistant thread frame: {error}"))
                     })?;
                 thread = Some(AssistantThread::from(payload));
+            }
+            "thread.html" => {
+                thread_html = Some(payload.to_string());
             }
             "messages.json" => {
                 let payloads: Vec<AssistantMessagePayload> = serde_json::from_str(payload)
@@ -3840,20 +3846,80 @@ fn parse_assistant_thread_open_stream(
         }
     }
 
+    let thread = match (thread, thread_html) {
+        (Some(thread), _) => Ok(thread),
+        (None, Some(html)) => parse_assistant_thread_open_html(&html),
+        (None, None) => Err(KagiError::Parse(format!(
+            "assistant thread open response did not include a thread.json or thread.html frame (received tags: {})",
+            format_received_frame_tags(&received_tags)
+        ))),
+    }?;
+
     Ok(AssistantThreadOpenResponse {
         meta,
         folders,
-        thread: thread.ok_or_else(|| {
-            KagiError::Parse(
-                "assistant thread open response did not include a thread.json frame".to_string(),
-            )
-        })?,
+        thread,
         messages: messages.ok_or_else(|| {
             KagiError::Parse(
                 "assistant thread open response did not include a messages.json frame".to_string(),
             )
         })?,
     })
+}
+
+fn parse_assistant_thread_open_html(html: &str) -> Result<AssistantThread, KagiError> {
+    let document = Html::parse_fragment(html);
+    let thread_selector = selector(".thread")?;
+    let title_selector = selector(".title")?;
+
+    let element = document
+        .select(&thread_selector)
+        .next()
+        .ok_or_else(|| KagiError::Parse("assistant thread html missing thread item".to_string()))?;
+    let id = element
+        .value()
+        .attr("data-code")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| KagiError::Parse("assistant thread html missing data-code".to_string()))?
+        .to_string();
+    let title = element
+        .select(&title_selector)
+        .next()
+        .map(|node| node.text().collect::<String>().trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| KagiError::Parse("assistant thread html missing title".to_string()))?;
+
+    Ok(AssistantThread {
+        id,
+        title,
+        ack: String::new(),
+        created_at: String::new(),
+        expires_at: String::new(),
+        saved: element
+            .value()
+            .attr("data-saved")
+            .is_some_and(|value| value == "true"),
+        shared: element
+            .value()
+            .attr("data-public")
+            .is_some_and(|value| value == "true"),
+        branch_id: String::new(),
+        folder_ids: Vec::new(),
+    })
+}
+
+fn format_received_frame_tags(tags: &[String]) -> String {
+    if tags.is_empty() {
+        "<none>".to_string()
+    } else {
+        tags.join(", ")
+    }
+}
+
+fn selector(value: &str) -> Result<Selector, KagiError> {
+    Selector::parse(value)
+        .map_err(|error| KagiError::Parse(format!("failed to parse selector `{value}`: {error:?}")))
 }
 
 fn parse_assistant_thread_list_stream(
@@ -5784,6 +5850,58 @@ mod tests {
         assert_eq!(parsed.thread.id, "thread-1");
         assert_eq!(parsed.messages.len(), 1);
         assert_eq!(parsed.messages[0].trace_id.as_deref(), Some("trace-msg"));
+    }
+
+    #[test]
+    fn parses_assistant_thread_open_stream_with_thread_html_fallback() {
+        let raw = concat!(
+            "hi:{\"v\":\"202603171911.stage.707e740\",\"trace\":\"trace-open-html\"}\0\n",
+            "tags.json:[]\0\n",
+            "thread.html:<li class=\"thread\"\n",
+            "    data-code=\"bb8254ea-4b02-4353-be53-b1bd8632e55e\"\n",
+            "    data-saved=\"false\"\n",
+            "    data-public=\"false\"\n",
+            "    data-tags=\"[]\"\n",
+            "    data-snippet=\"none\"\n",
+            "    >\n",
+            "  <i title=\"Temporary\">temp</i>\n",
+            "  <a href=\"/assistant/thread/bb8254ea-4b02-4353-be53-b1bd8632e55e\">\n",
+            "    <span class=\"title\">Testing Conversation</span>\n",
+            "  </a>\n",
+            "</li>\0\n",
+            "messages.json:[{\"id\":\"msg-1\",\"thread_id\":\"bb8254ea-4b02-4353-be53-b1bd8632e55e\",\"created_at\":\"2026-03-16T06:19:07Z\",\"branch_list\":[],\"state\":\"done\",\"prompt\":\"Hello\",\"reply\":\"<p>Hi</p>\",\"md\":\"Hi\",\"metadata\":\"\",\"documents\":[],\"trace_id\":\"trace-msg\"}]\0\n"
+        );
+
+        let parsed = parse_assistant_thread_open_stream(raw).expect("thread open parses from html");
+
+        assert_eq!(parsed.meta.trace.as_deref(), Some("trace-open-html"));
+        assert_eq!(parsed.thread.id, "bb8254ea-4b02-4353-be53-b1bd8632e55e");
+        assert_eq!(parsed.thread.title, "Testing Conversation");
+        assert!(!parsed.thread.saved);
+        assert!(!parsed.thread.shared);
+        assert!(parsed.thread.ack.is_empty());
+        assert!(parsed.thread.created_at.is_empty());
+        assert!(parsed.thread.expires_at.is_empty());
+        assert!(parsed.thread.branch_id.is_empty());
+        assert!(parsed.thread.folder_ids.is_empty());
+        assert_eq!(parsed.messages.len(), 1);
+    }
+
+    #[test]
+    fn reports_received_tags_when_thread_open_stream_has_no_thread_frame() {
+        let raw = concat!(
+            "hi:{\"v\":\"202603171911.stage.707e740\",\"trace\":\"trace-open-missing\"}\0\n",
+            "tags.json:[]\0\n",
+            "messages.json:[{\"id\":\"msg-1\",\"thread_id\":\"thread-1\",\"created_at\":\"2026-03-16T06:19:07Z\",\"branch_list\":[],\"state\":\"done\",\"prompt\":\"Hello\",\"reply\":\"<p>Hi</p>\",\"md\":\"Hi\",\"metadata\":\"\",\"documents\":[],\"trace_id\":\"trace-msg\"}]\0\n"
+        );
+
+        let error = parse_assistant_thread_open_stream(raw)
+            .expect_err("missing thread frame should fail to parse");
+
+        assert_eq!(
+            error.to_string(),
+            "parse error: assistant thread open response did not include a thread.json or thread.html frame (received tags: hi, tags.json, messages.json)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Kagi changed the Assistant backend and some accounts no longer receive the `thread.json` frame in `thread_open` responses for new threads. Old threads still work because they respond with the legacy format.

## Changes

- **`thread.html` fallback**: when `thread.json` is absent but `thread.html` is present, parse thread metadata (id, title, saved, shared) from the HTML frame. Fields not present in the HTML (`ack`, `created_at`, `expires_at`, `branch_id`, `folder_ids`) default to empty.
- **Improved error message**: when neither `thread.json` nor `thread.html` is present, the error now lists which frame tags were actually received, making future breakage easier to diagnose.
- **Two regression tests**: one for the HTML fallback path, one for the improved error message.

Fixes #123

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `thread.html` fallback parser to handle Kagi's backend change where new threads no longer receive a `thread.json` frame in `thread_open` responses. The error message for the missing-frame case is also improved to list the actual received frame tags.

- **HTML fallback**: `parse_assistant_thread_open_html` parses the `<li class=\"thread\">` element for `id`, `title`, `saved`, `shared`, and `folder_ids`; fields unavailable in HTML (`ack`, `created_at`, `expires_at`, `branch_id`) default to empty strings, matching the documented behaviour.
- **Received-tag tracking**: a `received_tags` vector is populated on every parsed frame and formatted into the error message when neither `thread.json` nor `thread.html` is found, greatly aiding future diagnosis.
- **Tests**: two new unit tests cover the HTML fallback path (including multi-value `folder_ids`) and the improved error-message path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive and isolated to the thread_open stream parser, with no modifications to existing frame handling or data structures.

The HTML fallback path correctly prefers thread.json when both frames are present, gracefully populates unavailable fields with empty defaults, and handles missing elements with explicit errors. Frame splitting via split_once(':') correctly preserves colons inside the HTML payload. Two new tests exercise the full happy-path and the improved error message. Version bumps are consistent across all manifests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/api.rs | Adds thread.html fallback parsing and improved error diagnostics in parse_assistant_thread_open_stream; new parse_assistant_thread_open_html and format_received_frame_tags helpers are well-tested and correct. |
| Cargo.toml | Version bumped from 0.14.0 to 0.14.1 for patch release. |
| Cargo.lock | Lock file updated to reflect the version bump; no dependency changes. |
| npm/package.json | npm wrapper version bumped to 0.14.1 in sync with Cargo.toml. |
| CHANGELOG.md | Changelog entry added for 0.14.1 describing the thread.html fallback and improved error message. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[thread_open stream frames] --> B{frame tag?}
    B -->|thread.json| C[Parse JSON → AssistantThread]
    B -->|thread.html| D[Store raw HTML]
    B -->|messages.json| E[Parse messages]
    B -->|other| F[Handle hi / tags / folders / etc.]
    C --> G{thread resolved?}
    D --> G
    G -->|Some thread.json| H[Use JSON thread ✓]
    G -->|None + Some thread.html| I[parse_assistant_thread_open_html]
    G -->|None + None| J[Error: list received_tags]
    I --> K{.thread element found?}
    K -->|yes| L[Extract id, title, saved, shared, folder_ids]
    K -->|no| M[Error: missing thread item]
    L --> N[Return AssistantThread with empty ack/created_at/expires_at/branch_id]
    H --> O[AssistantThreadOpenResponse]
    N --> O
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[thread_open stream frames] --> B{frame tag?}
    B -->|thread.json| C[Parse JSON → AssistantThread]
    B -->|thread.html| D[Store raw HTML]
    B -->|messages.json| E[Parse messages]
    B -->|other| F[Handle hi / tags / folders / etc.]
    C --> G{thread resolved?}
    D --> G
    G -->|Some thread.json| H[Use JSON thread ✓]
    G -->|None + Some thread.html| I[parse_assistant_thread_open_html]
    G -->|None + None| J[Error: list received_tags]
    I --> K{.thread element found?}
    K -->|yes| L[Extract id, title, saved, shared, folder_ids]
    K -->|no| M[Error: missing thread item]
    L --> N[Return AssistantThread with empty ack/created_at/expires_at/branch_id]
    H --> O[AssistantThreadOpenResponse]
    N --> O
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(assistant): parse folder\_ids from da..."](https://github.com/microck/kagi-cli/commit/37d7809e09ce0572aec7cc30a52bfdaf7f4d93b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41820900)</sub>

<!-- /greptile_comment -->