### PR TITLE
feat: add nix flake packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ scoop install kagi
 yay -S kagi-cli
 ```
 
+### nix / nixos
+
+run it without installing:
+
+```bash
+nix run github:Microck/kagi-cli -- search "rust async"
+```
+
+install it into your Nix profile:
+
+```bash
+nix profile install github:Microck/kagi-cli
+```
+
+for NixOS or home-manager, add the flake as an input and use its default
+package or `overlays.default`.
+
 ### auth
 
 run the guided setup:

--- a/docs/guides/installation.mdx
+++ b/docs/guides/installation.mdx
@@ -17,6 +17,7 @@ The *kagi* CLI can be installed through several methods:
 | Package Managers | System integration | Low | Automatic |
 | GitHub Releases | Specific versions | Medium | Manual |
 | Build from Source | Development, customization | High | Manual |
+| Nix Flake | NixOS, Home Manager, reproducible installs | Medium | Manual |
 
 ## Quick Install (Recommended)
 
@@ -190,6 +191,26 @@ cargo install --path .
 ```
 
 **Note on crates.io:** The package is not currently published to crates.io because both `kagi` and `kagi-cli` names are already taken. GitHub Releases remain the canonical distribution method.
+
+### Nix / NixOS
+
+The repository includes a flake for Nix users. It provides the CLI package, a runnable app, shell completions, and a development shell.
+
+Run the CLI without installing it:
+
+```bash
+nix run github:Microck/kagi-cli -- search "rust async"
+```
+
+Install it into your Nix profile:
+
+```bash
+nix profile install github:Microck/kagi-cli
+```
+
+For NixOS or Home Manager, add `github:Microck/kagi-cli` as a flake input. Use `kagi.packages.${system}.default` for the package or `kagi.overlays.default` in your package set.
+
+Authentication works the same as with other installation methods. Run `kagi auth` after installation or set the required Kagi environment variable.
 
 ## Manual Installation from GitHub Releases
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "terminal CLI for Kagi subscribers with JSON-first search output";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    let
+      overlay = final: prev: {
+        kagi = final.callPackage ./nix/kagi.nix { };
+      };
+    in
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
+        };
+      in
+      {
+        packages = {
+          default = pkgs.kagi;
+          kagi = pkgs.kagi;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${pkgs.kagi}/bin/kagi";
+          meta.description = "Run the kagi CLI";
+        };
+
+        checks.kagi = pkgs.kagi;
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ pkgs.kagi ];
+          packages = with pkgs; [
+            cargo
+            rustc
+            clippy
+            rustfmt
+            rust-analyzer
+          ];
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+        };
+
+        formatter = pkgs.nixfmt;
+      }
+    )
+    // {
+      overlays.default = overlay;
+    };
+}

--- a/nix/kagi.nix
+++ b/nix/kagi.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  installShellFiles,
+  stdenv,
+}:
+
+let
+  cargoToml = lib.importTOML ../Cargo.toml;
+in
+rustPlatform.buildRustPackage {
+  pname = cargoToml.package.name;
+  version = cargoToml.package.version;
+
+  src = lib.cleanSource ../.;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  # reqwest uses rustls-tls, so the package does not need OpenSSL or pkg-config.
+  nativeBuildInputs = [ installShellFiles ];
+
+  # The test suite uses local mock servers and can run in the sandbox.
+  doCheck = true;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd kagi \
+      --bash <($out/bin/kagi --generate-completion bash) \
+      --zsh  <($out/bin/kagi --generate-completion zsh) \
+      --fish <($out/bin/kagi --generate-completion fish)
+  '';
+
+  meta = {
+    description = cargoToml.package.description;
+    homepage = "https://github.com/Microck/kagi-cli";
+    changelog = "https://github.com/Microck/kagi-cli/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "kagi";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/nix/kagi.nix
+++ b/nix/kagi.nix
@@ -18,8 +18,8 @@ rustPlatform.buildRustPackage {
   # reqwest uses rustls-tls, so the package does not need OpenSSL or pkg-config.
   nativeBuildInputs = [ installShellFiles ];
 
-  # The test suite uses local mock servers and can run in the sandbox.
-  doCheck = true;
+  # Skip tests when the build host cannot execute the target binary.
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kagi \


### PR DESCRIPTION
## what changed

adds first-class nix packaging for kagi-cli:

- adds a reproducible `flake.nix` and `flake.lock`
- exposes `packages.default`, `apps.default`, `checks.kagi`, `devShells.default`, and `overlays.default`
- packages the existing Cargo project with `rustPlatform.buildRustPackage`
- installs bash, zsh, and fish completions from the built binary
- documents `nix run` and `nix profile install`

## why

kagi-cli is already a good fit for nix: it is a locked Rust project that builds a standalone binary and uses rustls instead of OpenSSL. this gives NixOS and home-manager users a declarative install path without changing the existing installers or release workflow.

## verification

- `cargo fmt --check`
- `cargo check --workspace --all-targets --locked`
- `cargo test --workspace --all-targets --locked`
- 273 tests passed, 13 live tests ignored

`nix flake check` was not run because nix is not installed in the verification environment.

implementation with Hermes, verified locally with the existing Rust toolchain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nix/NixOS installation support, including direct execution, profile installation, and flake integration.
  * Added a Nix package, runnable app, development shell, formatter, overlay, and package checks.

* **Documentation**
  * Added setup instructions for using the application with Nix, NixOS, and home-manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds first-class Nix flake packaging for the Rust CLI.
- Exposes default package, app, check, development shell, formatter, and overlay outputs.
- Builds the existing Cargo project and generates shell completions when the build platform can execute target binaries.
- Documents Nix execution, profile installation, NixOS, and Home Manager usage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the prior cross-build issue is fixed by skipping target test execution when the build platform cannot execute host-platform binaries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| flake.nix | Defines per-system package, app, check, development shell, formatter, and exported overlay outputs. |
| nix/kagi.nix | Packages the Cargo project, correctly guards tests and completion generation by target executability, and defines package metadata. |
| flake.lock | Pins the nixpkgs, flake-utils, and systems inputs used by the new flake. |
| README.md | Adds concise Nix run, profile installation, NixOS, and Home Manager guidance. |
| docs/guides/installation.mdx | Adds Nix installation and authentication instructions to the installation guide. |

<sub>Reviews (3): Last reviewed commit: ["docs: add nix installation guide"](https://github.com/microck/kagi-cli/commit/4a3b9bf0b9912c2f8fcf980b1ac430fb65541817) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48913604)</sub>

<!-- /greptile_comment -->