### PR TITLE
feat: update kagi mcp to MCP 2026-07-28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `kagi mcp` to MCP `2026-07-28`: requests use per-request metadata, `server/discover` replaces the legacy initialization handshake, list results expose cache hints, tool metadata includes behavior annotations, and JSON tool output is also available as `structuredContent`.
+- MCP tool execution failures now use `isError: true` tool results so agents can inspect and correct failed calls. Unknown tools and malformed protocol requests remain JSON-RPC errors.
+
+### Breaking
+
+- `kagi mcp` no longer accepts the legacy initialization handshake. MCP clients must send `params._meta.io.modelcontextprotocol/protocolVersion` and `params._meta.io.modelcontextprotocol/clientCapabilities` on every request.
+
 ## [0.16.1]
 
 ### Added

--- a/docs/commands/mcp.mdx
+++ b/docs/commands/mcp.mdx
@@ -5,7 +5,8 @@ description: "Run kagi-cli as a stdio Model Context Protocol server."
 
 # `kagi mcp`
 
-Run a stdio JSON-RPC server that exposes Kagi tools for agents.
+Run a stdio MCP server that exposes Kagi tools for agents. The server speaks
+MCP `2026-07-28`, the stateless protocol with per-request metadata.
 
 ## Synopsis
 
@@ -91,6 +92,37 @@ codex mcp add kagi-mcp -- "$(command -v kagi)" mcp
 
 Restart Codex after changing MCP entries so the tool list is rediscovered.
 
+The server does not use the legacy `initialize` handshake or protocol session.
+Every request, including `server/discover`, sends the protocol version, client
+identity, and client capabilities in `params._meta`. Clients can call
+`server/discover` first with a preferred version and retry with a supported
+version if the server returns an unsupported-version error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "server/discover",
+  "params": {
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "my-agent",
+        "version": "1.0.0"
+      },
+      "io.modelcontextprotocol/clientCapabilities": {}
+    }
+  }
+}
+```
+
+Discovery and tool-list responses include `resultType`, `ttlMs`, and
+`cacheScope` so clients can cache stable metadata. Tool calls return
+`structuredContent` when the selected output format is JSON. Kagi API and
+validation failures are returned as tool results with `isError: true`, which
+lets an agent inspect and correct the call. Unknown tools and malformed MCP
+requests remain JSON-RPC errors.
+
 To use a named profile from `./.kagi.toml`, put `--profile` after `mcp`:
 
 ```bash
@@ -119,9 +151,8 @@ Default read/query tools:
 - `kagi_quick` - Quick Answer with lens, cache, and output options.
 - `kagi_news`, `kagi_news_categories`, `kagi_news_chaos`, and `kagi_news_filter_presets` - public Kagi News feed and metadata.
 - `kagi_news_search` - subscriber News-tab search clusters.
-- `kagi_assistant`, `kagi_assistant_models`, `kagi_assistant_thread_list`, `kagi_assistant_thread_get`, and `kagi_assistant_thread_export` - Assistant prompt and thread reads.
+- `kagi_assistant_models`, `kagi_assistant_thread_list`, `kagi_assistant_thread_get`, and `kagi_assistant_thread_export` - Assistant model and thread reads.
 - `kagi_assistant_custom_list` and `kagi_assistant_custom_get` - read saved assistant definitions.
-- `kagi_ask_page` - page-focused Assistant question.
 - `kagi_translate` - Kagi Translate text mode.
 - `kagi_fastgpt` - FastGPT API answers.
 - `kagi_enrich_web` and `kagi_enrich_news` - enrichment indexes.
@@ -132,6 +163,7 @@ Default read/query tools:
 
 Tools exposed only with `--enable-mutating-tools`:
 
+- `kagi_assistant` and `kagi_ask_page` - prompt Assistant in a way that creates or extends conversations.
 - `kagi_assistant_thread_delete`
 - `kagi_assistant_custom_create`, `kagi_assistant_custom_update`, `kagi_assistant_custom_delete`
 - `kagi_lens_create`, `kagi_lens_update`, `kagi_lens_delete`, `kagi_lens_enable`, `kagi_lens_disable`
@@ -140,7 +172,9 @@ Tools exposed only with `--enable-mutating-tools`:
 - `kagi_site_pref_set`, `kagi_site_pref_remove`
 - `kagi_cli` - run any non-`mcp` `kagi` command by passing an `args` array and optional `stdin`. Use this for exact CLI parity when a workflow is not modeled as a structured MCP tool.
 
-The server reads one JSON-RPC request per stdin line and writes one JSON-RPC response per stdout line. This keeps the implementation dependency-light and easy to supervise from agent runners.
+The server reads one MCP request or notification per stdin line and writes one
+MCP response per stdout line. It keeps the implementation dependency-light and
+easy to supervise from agent runners.
 
 ## Authentication
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3123,9 +3123,42 @@ async fn run_assistant_repl(args: AssistantReplArgs, token: &str) -> Result<(), 
 struct McpServerConfig {
     default_output: Option<OutputFormat>,
     enable_mutating_tools: bool,
+    tool_definitions: Vec<Value>,
+}
+
+const MCP_PROTOCOL_VERSION: &str = "2026-07-28";
+const MCP_PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
+const MCP_CLIENT_INFO_META_KEY: &str = "io.modelcontextprotocol/clientInfo";
+const MCP_CLIENT_CAPABILITIES_META_KEY: &str = "io.modelcontextprotocol/clientCapabilities";
+const MCP_CACHE_TTL_MS: u64 = 3_600_000;
+
+#[derive(Debug)]
+struct McpProtocolError {
+    code: i64,
+    message: String,
+    data: Option<Value>,
+}
+
+impl McpProtocolError {
+    fn invalid_params(message: impl Into<String>) -> Self {
+        Self {
+            code: -32602,
+            message: message.into(),
+            data: None,
+        }
+    }
 }
 
 impl McpServerConfig {
+    fn new(default_output: Option<OutputFormat>, enable_mutating_tools: bool) -> Self {
+        let tool_definitions = build_mcp_tool_definitions(enable_mutating_tools);
+        Self {
+            default_output,
+            enable_mutating_tools,
+            tool_definitions,
+        }
+    }
+
     fn default_output_or(&self, fallback: OutputFormat) -> OutputFormat {
         self.default_output.clone().unwrap_or(fallback)
     }
@@ -3133,10 +3166,7 @@ impl McpServerConfig {
 
 async fn run_mcp(args: McpArgs, profile: Option<&str>) -> Result<(), KagiError> {
     let _json_lines = args.json_lines;
-    let config = McpServerConfig {
-        default_output: args.default_output,
-        enable_mutating_tools: args.enable_mutating_tools,
-    };
+    let config = McpServerConfig::new(args.default_output, args.enable_mutating_tools);
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         let line =
@@ -3156,41 +3186,50 @@ async fn run_mcp(args: McpArgs, profile: Option<&str>) -> Result<(), KagiError> 
         let Some(id) = request.get("id").cloned() else {
             continue;
         };
-        let method = request.get("method").and_then(Value::as_str).unwrap_or("");
-        let response = match method {
-            "initialize" => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": {
-                    "protocolVersion": "2024-11-05",
-                    "serverInfo": {"name": "kagi-cli", "version": env!("CARGO_PKG_VERSION")},
-                    "capabilities": {"tools": {}}
-                }
-            }),
-            "tools/list" => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": {
-                    "tools": mcp_tool_definitions(&config)
-                }
-            }),
-            "tools/call" => match run_mcp_tool_call(&request, profile, &config).await {
-                Ok(result) => serde_json::json!({
+
+        let Some(method) = request.get("method").and_then(Value::as_str) else {
+            let response = json_rpc_error(id, -32600, "Invalid Request: method is required".into());
+            println!("{}", serde_json::to_string(&response)?);
+            continue;
+        };
+
+        let response = match validate_mcp_request(&request) {
+            Ok(()) => match method {
+                "server/discover" => serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": result,
+                    "result": mcp_discover_result(),
                 }),
-                Err(error) => serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "error": {"code": -32000, "message": error.to_string()},
-                }),
+                "tools/list" => match mcp_tools_list_result(&request, &config) {
+                    Ok(result) => serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": result,
+                    }),
+                    Err(error) => {
+                        json_rpc_error_with_data(id, error.code, error.message, error.data)
+                    }
+                },
+                "tools/call" => match validate_mcp_tool_call(&request, &config) {
+                    Ok(()) => match run_mcp_tool_call(&request, profile, &config).await {
+                        Ok(result) => serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": result,
+                        }),
+                        Err(error) => serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": mcp_tool_result(error.to_string(), true, false),
+                        }),
+                    },
+                    Err(error) => {
+                        json_rpc_error_with_data(id, error.code, error.message, error.data)
+                    }
+                },
+                _ => json_rpc_error(id, -32601, format!("Method not found: {method}")),
             },
-            _ => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "error": {"code": -32601, "message": format!("Method not found: {method}")},
-            }),
+            Err(error) => json_rpc_error_with_data(id, error.code, error.message, error.data),
         };
         println!("{}", serde_json::to_string(&response)?);
     }
@@ -3198,14 +3237,248 @@ async fn run_mcp(args: McpArgs, profile: Option<&str>) -> Result<(), KagiError> 
 }
 
 fn json_rpc_error(id: Value, code: i64, message: String) -> Value {
+    json_rpc_error_with_data(id, code, message, None)
+}
+
+fn json_rpc_error_with_data(id: Value, code: i64, message: String, data: Option<Value>) -> Value {
+    let mut error = serde_json::json!({
+        "code": code,
+        "message": message,
+    });
+    if let Some(data) = data {
+        error["data"] = data;
+    }
+
     serde_json::json!({
         "jsonrpc": "2.0",
         "id": id,
-        "error": {"code": code, "message": message},
+        "error": error,
     })
 }
 
-fn mcp_tool_definitions(config: &McpServerConfig) -> Value {
+fn validate_mcp_request(request: &Value) -> Result<(), McpProtocolError> {
+    if request.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return Err(McpProtocolError {
+            code: -32600,
+            message: "Invalid Request: jsonrpc must be \"2.0\"".to_string(),
+            data: None,
+        });
+    }
+
+    let params = request
+        .get("params")
+        .and_then(Value::as_object)
+        .ok_or_else(|| McpProtocolError::invalid_params("MCP request params must be an object"))?;
+    let meta = params
+        .get("_meta")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            McpProtocolError::invalid_params(
+                "MCP request params._meta must include protocolVersion and clientCapabilities",
+            )
+        })?;
+    let requested_version = meta
+        .get(MCP_PROTOCOL_VERSION_META_KEY)
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            McpProtocolError::invalid_params(format!(
+                "MCP request params._meta.{MCP_PROTOCOL_VERSION_META_KEY} is required"
+            ))
+        })?;
+    if requested_version != MCP_PROTOCOL_VERSION {
+        return Err(McpProtocolError {
+            code: -32022,
+            message: "Unsupported protocol version".to_string(),
+            data: Some(serde_json::json!({
+                "supported": [MCP_PROTOCOL_VERSION],
+                "requested": requested_version,
+            })),
+        });
+    }
+
+    if !meta
+        .get(MCP_CLIENT_CAPABILITIES_META_KEY)
+        .is_some_and(Value::is_object)
+    {
+        return Err(McpProtocolError::invalid_params(format!(
+            "MCP request params._meta.{MCP_CLIENT_CAPABILITIES_META_KEY} is required and must be an object"
+        )));
+    }
+
+    if let Some(client_info) = meta.get(MCP_CLIENT_INFO_META_KEY) {
+        let valid_client_info = client_info.as_object().is_some_and(|client_info| {
+            client_info.get("name").and_then(Value::as_str).is_some()
+                && client_info.get("version").and_then(Value::as_str).is_some()
+        });
+        if !valid_client_info {
+            return Err(McpProtocolError::invalid_params(format!(
+                "MCP request params._meta.{MCP_CLIENT_INFO_META_KEY} must include name and version"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn mcp_discover_result() -> Value {
+    serde_json::json!({
+        "resultType": "complete",
+        "supportedVersions": [MCP_PROTOCOL_VERSION],
+        "capabilities": {
+            "tools": {}
+        },
+        "_meta": {
+            "io.modelcontextprotocol/serverInfo": {
+                "name": "kagi-cli",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        },
+        "instructions": "Search Kagi web and news, extract and summarize pages, inspect Assistant threads, and inspect Kagi account or local CLI state. Prompting Assistant or changing account and local state requires --enable-mutating-tools.",
+        "ttlMs": MCP_CACHE_TTL_MS,
+        "cacheScope": "public"
+    })
+}
+
+fn mcp_tools_list_result(
+    request: &Value,
+    config: &McpServerConfig,
+) -> Result<Value, McpProtocolError> {
+    let params = request
+        .get("params")
+        .and_then(Value::as_object)
+        .expect("validated MCP request params should be an object");
+    if params.get("cursor").is_some_and(|cursor| !cursor.is_null()) {
+        return Err(McpProtocolError::invalid_params(
+            "MCP tools/list does not issue pagination cursors because the complete tool catalog fits in one response",
+        ));
+    }
+
+    Ok(serde_json::json!({
+        "resultType": "complete",
+        "tools": config.tool_definitions.clone(),
+        "ttlMs": MCP_CACHE_TTL_MS,
+        "cacheScope": "public"
+    }))
+}
+
+fn validate_mcp_tool_call(
+    request: &Value,
+    config: &McpServerConfig,
+) -> Result<(), McpProtocolError> {
+    let params = request
+        .get("params")
+        .and_then(Value::as_object)
+        .expect("validated MCP request params should be an object");
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .ok_or_else(|| {
+            McpProtocolError::invalid_params("MCP tools/call requires a non-empty name")
+        })?;
+    if !config
+        .tool_definitions
+        .iter()
+        .any(|tool| tool["name"].as_str() == Some(name))
+    {
+        return Err(McpProtocolError {
+            code: -32602,
+            message: format!("Unknown tool: {name}"),
+            data: None,
+        });
+    }
+
+    if let Some(arguments) = params.get("arguments")
+        && !arguments.is_object()
+    {
+        return Err(McpProtocolError::invalid_params(
+            "MCP tools/call arguments must be an object",
+        ));
+    }
+
+    Ok(())
+}
+
+fn mcp_tool_result(text: String, is_error: bool, include_structured_content: bool) -> Value {
+    let mut result = serde_json::json!({
+        "resultType": "complete",
+        "content": [{ "type": "text", "text": text }],
+        "isError": is_error,
+    });
+    if include_structured_content && !is_error {
+        let text = result["content"][0]["text"]
+            .as_str()
+            .expect("MCP text content should be a string");
+        if let Ok(structured_content) = serde_json::from_str::<Value>(text) {
+            result["structuredContent"] = structured_content;
+        }
+    }
+    result
+}
+
+fn mcp_tool_has_structured_content(
+    name: &str,
+    arguments: &Value,
+    config: &McpServerConfig,
+) -> Result<bool, KagiError> {
+    let default = config.default_output_or(OutputFormat::Json);
+    // Only these tools honor a per-call `format` field. The remaining tools
+    // either use the server default, always return text, or have a format
+    // mapping handled explicitly below.
+    match name {
+        "kagi_auth_status" | "kagi_auth_check" => Ok(false),
+        "kagi_extract" => Ok(matches!(
+            mcp_extract_output_format(arguments, config)?,
+            OutputFormat::Json | OutputFormat::Compact
+        )),
+        "kagi_quick" => Ok(matches!(
+            mcp_quick_format(arguments, &default)?,
+            QuickOutputFormat::Json | QuickOutputFormat::Compact
+        )),
+        "kagi_assistant" => Ok(matches!(
+            mcp_assistant_format(arguments, &default)?,
+            AssistantOutputFormat::Json | AssistantOutputFormat::Compact
+        )),
+        "kagi_assistant_thread_export" => {
+            match mcp_string_or(arguments, "format", "markdown").as_str() {
+                "json" => Ok(true),
+                "markdown" => Ok(false),
+                other => Err(KagiError::Config(format!(
+                    "unsupported thread export format `{other}`. Use markdown or json"
+                ))),
+            }
+        }
+        "kagi_search" => {
+            let is_json = is_structured_output_format(&mcp_output_format(arguments, &default)?);
+            let uses_template = arguments.get("template").and_then(Value::as_str).is_some()
+                && arguments.get("news").and_then(Value::as_bool) != Some(true);
+            Ok(is_json && !uses_template)
+        }
+        "kagi_batch_search"
+        | "kagi_summarize"
+        | "kagi_news"
+        | "kagi_news_categories"
+        | "kagi_news_chaos"
+        | "kagi_news_filter_presets"
+        | "kagi_news_search"
+        | "kagi_ask_page"
+        | "kagi_translate"
+        | "kagi_fastgpt"
+        | "kagi_enrich_web"
+        | "kagi_enrich_news"
+        | "kagi_smallweb"
+        | "kagi_cli" => Ok(is_structured_output_format(&mcp_output_format(
+            arguments, &default,
+        )?)),
+        _ => Ok(is_structured_output_format(&default)),
+    }
+}
+
+fn is_structured_output_format(format: &OutputFormat) -> bool {
+    matches!(format, OutputFormat::Json | OutputFormat::Compact)
+}
+
+fn build_mcp_tool_definitions(enable_mutating_tools: bool) -> Vec<Value> {
     let mut tools = vec![
         tool_schema(
             "kagi_search",
@@ -3254,11 +3527,6 @@ fn mcp_tool_definitions(config: &McpServerConfig) -> Value {
             news_search_schema(),
         ),
         tool_schema(
-            "kagi_assistant",
-            "Prompt Kagi Assistant",
-            assistant_schema(),
-        ),
-        tool_schema(
             "kagi_assistant_models",
             "List Assistant base-model slugs",
             empty_schema(),
@@ -3287,11 +3555,6 @@ fn mcp_tool_definitions(config: &McpServerConfig) -> Value {
             "kagi_assistant_custom_get",
             "Fetch a custom assistant by id or name",
             target_schema("target", "Custom assistant id or exact name"),
-        ),
-        tool_schema(
-            "kagi_ask_page",
-            "Ask Assistant about a page",
-            ask_page_schema(),
         ),
         tool_schema(
             "kagi_translate",
@@ -3363,8 +3626,18 @@ fn mcp_tool_definitions(config: &McpServerConfig) -> Value {
         ),
     ];
 
-    if config.enable_mutating_tools {
+    if enable_mutating_tools {
         tools.extend([
+            tool_schema(
+                "kagi_assistant",
+                "Prompt Kagi Assistant",
+                assistant_schema(),
+            ),
+            tool_schema(
+                "kagi_ask_page",
+                "Ask Assistant about a page",
+                ask_page_schema(),
+            ),
             tool_schema(
                 "kagi_assistant_thread_delete",
                 "Delete an Assistant thread",
@@ -3468,7 +3741,13 @@ fn mcp_tool_definitions(config: &McpServerConfig) -> Value {
         ]);
     }
 
-    Value::Array(tools)
+    tools.sort_by(|left, right| {
+        left["name"]
+            .as_str()
+            .unwrap_or_default()
+            .cmp(right["name"].as_str().unwrap_or_default())
+    });
+    tools
 }
 
 fn tool_schema(name: &str, description: &str, input_schema: Value) -> Value {
@@ -3476,11 +3755,114 @@ fn tool_schema(name: &str, description: &str, input_schema: Value) -> Value {
         "name": name,
         "description": description,
         "inputSchema": input_schema,
+        "annotations": mcp_tool_annotations(name),
     })
+}
+
+fn mcp_tool_annotations(name: &str) -> Value {
+    let read_only = !mcp_mutating_tool_name(name);
+    let mut annotations = serde_json::json!({
+        "readOnlyHint": read_only,
+        "openWorldHint": mcp_open_world_tool_name(name),
+    });
+    if !read_only {
+        if mcp_destructive_tool_name(name) {
+            annotations["destructiveHint"] = serde_json::json!(true);
+        }
+        annotations["idempotentHint"] = serde_json::json!(mcp_idempotent_tool_name(name));
+    }
+    annotations
+}
+
+fn mcp_mutating_tool_name(name: &str) -> bool {
+    matches!(
+        name,
+        "kagi_assistant"
+            | "kagi_ask_page"
+            | "kagi_assistant_thread_delete"
+            | "kagi_assistant_custom_create"
+            | "kagi_assistant_custom_update"
+            | "kagi_assistant_custom_delete"
+            | "kagi_lens_create"
+            | "kagi_lens_update"
+            | "kagi_lens_delete"
+            | "kagi_lens_enable"
+            | "kagi_lens_disable"
+            | "kagi_custom_bang_create"
+            | "kagi_custom_bang_update"
+            | "kagi_custom_bang_delete"
+            | "kagi_redirect_create"
+            | "kagi_redirect_update"
+            | "kagi_redirect_delete"
+            | "kagi_redirect_enable"
+            | "kagi_redirect_disable"
+            | "kagi_site_pref_set"
+            | "kagi_site_pref_remove"
+            | "kagi_cli"
+    )
+}
+
+fn mcp_destructive_tool_name(name: &str) -> bool {
+    matches!(
+        name,
+        "kagi_assistant_thread_delete"
+            | "kagi_assistant_custom_delete"
+            | "kagi_lens_delete"
+            | "kagi_custom_bang_delete"
+            | "kagi_redirect_delete"
+            | "kagi_site_pref_remove"
+            | "kagi_cli"
+    )
+}
+
+fn mcp_idempotent_tool_name(name: &str) -> bool {
+    matches!(
+        name,
+        "kagi_assistant_thread_delete"
+            | "kagi_assistant_custom_update"
+            | "kagi_assistant_custom_delete"
+            | "kagi_lens_update"
+            | "kagi_lens_delete"
+            | "kagi_lens_enable"
+            | "kagi_lens_disable"
+            | "kagi_custom_bang_update"
+            | "kagi_custom_bang_delete"
+            | "kagi_redirect_update"
+            | "kagi_redirect_delete"
+            | "kagi_redirect_enable"
+            | "kagi_redirect_disable"
+            | "kagi_site_pref_set"
+            | "kagi_site_pref_remove"
+    )
+}
+
+fn mcp_open_world_tool_name(name: &str) -> bool {
+    matches!(
+        name,
+        "kagi_search"
+            | "kagi_batch_search"
+            | "kagi_summarize"
+            | "kagi_extract"
+            | "kagi_quick"
+            | "kagi_news"
+            | "kagi_news_categories"
+            | "kagi_news_chaos"
+            | "kagi_news_filter_presets"
+            | "kagi_news_search"
+            | "kagi_assistant"
+            | "kagi_ask_page"
+            | "kagi_translate"
+            | "kagi_fastgpt"
+            | "kagi_enrich_web"
+            | "kagi_enrich_news"
+            | "kagi_smallweb"
+            | "kagi_cli"
+    )
 }
 
 fn object_schema(properties: Value, required: &[&str]) -> Value {
     serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": properties,
         "required": required,
@@ -3902,6 +4284,7 @@ async fn run_mcp_tool_call(
         .get("arguments")
         .cloned()
         .unwrap_or_else(|| serde_json::json!({}));
+    let include_structured_content = mcp_tool_has_structured_content(name, &arguments, config)?;
     let text = match name {
         "kagi_search" => mcp_search(&arguments, profile, config).await?,
         "kagi_batch_search" => mcp_batch_search(&arguments, profile, config).await?,
@@ -3922,7 +4305,6 @@ async fn run_mcp_tool_call(
             mcp_output_format(&arguments, &config.default_output_or(OutputFormat::Json))?,
         )?,
         "kagi_news_search" => mcp_news_search(&arguments, profile, config).await?,
-        "kagi_assistant" => mcp_assistant(&arguments, profile, config).await?,
         "kagi_assistant_models" => {
             let token = resolve_session_token(profile)?;
             mcp_output(
@@ -3964,21 +4346,6 @@ async fn run_mcp_tool_call(
                 &execute_custom_assistant_get(&mcp_required_string(&arguments, "target")?, &token)
                     .await?,
                 config.default_output_or(OutputFormat::Json),
-            )?
-        }
-        "kagi_ask_page" => {
-            let token = resolve_session_token(profile)?;
-            let response = execute_ask_page(
-                &AskPageRequest {
-                    url: mcp_required_string(&arguments, "url")?,
-                    question: mcp_required_string(&arguments, "question")?,
-                },
-                &token,
-            )
-            .await?;
-            mcp_output(
-                &response,
-                mcp_output_format(&arguments, &config.default_output_or(OutputFormat::Json))?,
             )?
         }
         "kagi_translate" => mcp_translate(&arguments, profile, config).await?,
@@ -4058,7 +4425,9 @@ async fn run_mcp_tool_call(
             &local::load_site_preferences()?,
             config.default_output_or(OutputFormat::Json),
         )?,
-        "kagi_assistant_thread_delete"
+        "kagi_assistant"
+        | "kagi_ask_page"
+        | "kagi_assistant_thread_delete"
         | "kagi_assistant_custom_create"
         | "kagi_assistant_custom_update"
         | "kagi_assistant_custom_delete"
@@ -4084,7 +4453,7 @@ async fn run_mcp_tool_call(
             )));
         }
     };
-    Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }))
+    Ok(mcp_tool_result(text, false, include_structured_content))
 }
 
 async fn mcp_mutating_tool_call(
@@ -4099,12 +4468,30 @@ async fn mcp_mutating_tool_call(
         )));
     }
 
+    if name == "kagi_assistant" {
+        return mcp_assistant(arguments, profile, config).await;
+    }
+
     if name == "kagi_cli" {
         return mcp_cli_passthrough(arguments, config);
     }
 
     let token = resolve_session_token(profile)?;
     match name {
+        "kagi_ask_page" => {
+            let response = execute_ask_page(
+                &AskPageRequest {
+                    url: mcp_required_string(arguments, "url")?,
+                    question: mcp_required_string(arguments, "question")?,
+                },
+                &token,
+            )
+            .await?;
+            mcp_output(
+                &response,
+                mcp_output_format(arguments, &config.default_output_or(OutputFormat::Json))?,
+            )
+        }
         "kagi_assistant_thread_delete" => mcp_output(
             &execute_assistant_thread_delete(&mcp_required_string(arguments, "thread_id")?, &token)
                 .await?,
@@ -4531,42 +4918,48 @@ async fn mcp_extract(
     config: &McpServerConfig,
 ) -> Result<String, KagiError> {
     let url = mcp_required_string(arguments, "url")?;
-    let format = arguments
+    match mcp_extract_output_format(arguments, config)? {
+        OutputFormat::Markdown => execute_extract_with_available_auth(&url, profile).await,
+        OutputFormat::Compact => {
+            let response = execute_extract_response_with_available_auth(&url, profile).await?;
+            serde_json::to_string(&response).map_err(KagiError::from)
+        }
+        OutputFormat::Toon => {
+            let response = execute_extract_response_with_available_auth(&url, profile).await?;
+            mcp_output(&response, OutputFormat::Toon)
+        }
+        OutputFormat::Json => {
+            let response = execute_extract_response_with_available_auth(&url, profile).await?;
+            mcp_output(&response, OutputFormat::Json)
+        }
+        OutputFormat::Pretty | OutputFormat::Csv => {
+            unreachable!("MCP extract format normalization should not return pretty or csv")
+        }
+    }
+}
+
+fn mcp_extract_output_format(
+    arguments: &Value,
+    config: &McpServerConfig,
+) -> Result<OutputFormat, KagiError> {
+    let requested = arguments
         .get("format")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_ascii_lowercase);
-    match format.as_deref() {
-        Some("markdown") => execute_extract_with_available_auth(&url, profile).await,
-        Some("compact") => {
-            let response = execute_extract_response_with_available_auth(&url, profile).await?;
-            serde_json::to_string(&response).map_err(KagiError::from)
-        }
-        Some("toon") => {
-            let response = execute_extract_response_with_available_auth(&url, profile).await?;
-            mcp_output(&response, OutputFormat::Toon)
-        }
-        Some("json") => {
-            let response = execute_extract_response_with_available_auth(&url, profile).await?;
-            mcp_output(&response, OutputFormat::Json)
-        }
+    match requested.as_deref() {
+        Some("markdown") => Ok(OutputFormat::Markdown),
+        Some("compact") => Ok(OutputFormat::Compact),
+        Some("toon") => Ok(OutputFormat::Toon),
+        Some("json") => Ok(OutputFormat::Json),
         None => match config.default_output.clone() {
             None | Some(OutputFormat::Markdown | OutputFormat::Pretty) => {
-                execute_extract_with_available_auth(&url, profile).await
+                Ok(OutputFormat::Markdown)
             }
-            Some(OutputFormat::Compact) => {
-                let response = execute_extract_response_with_available_auth(&url, profile).await?;
-                serde_json::to_string(&response).map_err(KagiError::from)
-            }
-            Some(OutputFormat::Toon) => {
-                let response = execute_extract_response_with_available_auth(&url, profile).await?;
-                mcp_output(&response, OutputFormat::Toon)
-            }
-            Some(OutputFormat::Json | OutputFormat::Csv) => {
-                let response = execute_extract_response_with_available_auth(&url, profile).await?;
-                mcp_output(&response, OutputFormat::Json)
-            }
+            Some(OutputFormat::Compact) => Ok(OutputFormat::Compact),
+            Some(OutputFormat::Toon) => Ok(OutputFormat::Toon),
+            Some(OutputFormat::Json | OutputFormat::Csv) => Ok(OutputFormat::Json),
         },
         Some(other) => Err(KagiError::Config(format!(
             "unsupported extract format `{other}`. Use markdown, json, compact, or toon"

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -327,6 +327,35 @@ fn env_refs(values: &[(impl AsRef<str>, impl AsRef<str>)]) -> Vec<(&str, &str)> 
         .collect()
 }
 
+fn mcp_request(id: Value, method: &str, params: Value) -> Value {
+    mcp_request_with_version(id, method, params, "2026-07-28")
+}
+
+fn mcp_request_with_version(id: Value, method: &str, params: Value, version: &str) -> Value {
+    let mut params = params
+        .as_object()
+        .expect("MCP test params should be an object")
+        .clone();
+    params.insert(
+        "_meta".to_string(),
+        json!({
+            "io.modelcontextprotocol/protocolVersion": version,
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "kagi-cli-integration-tests",
+                "version": "1.0.0"
+            },
+            "io.modelcontextprotocol/clientCapabilities": {}
+        }),
+    );
+
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": Value::Object(params),
+    })
+}
+
 fn session_env(server: &MockServer) -> Vec<(&'static str, String)> {
     vec![
         ("KAGI_SESSION_TOKEN", "test-session".to_string()),
@@ -2433,11 +2462,15 @@ fn site_pref_and_history_use_local_cache_dir() {
 }
 
 #[test]
-fn mcp_initialize_returns_server_info() {
+fn mcp_server_discover_returns_modern_server_info() {
     let tempdir = TempDir::new().expect("tempdir");
+    let request = mcp_request(json!(1), "server/discover", json!({}));
     let output = run_kagi_with_stdin(
         &["mcp"],
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n",
+        &format!(
+            "{}\n",
+            serde_json::to_string(&request).expect("request serializes")
+        ),
         &[],
         tempdir.path(),
     );
@@ -2445,7 +2478,17 @@ fn mcp_initialize_returns_server_info() {
     assert_success(&output);
     let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
     assert_eq!(response["id"], 1);
-    assert_eq!(response["result"]["serverInfo"]["name"], "kagi-cli");
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(
+        response["result"]["supportedVersions"],
+        json!(["2026-07-28"])
+    );
+    assert_eq!(
+        response["result"]["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+        "kagi-cli"
+    );
+    assert_eq!(response["result"]["ttlMs"], 3600000);
+    assert_eq!(response["result"]["cacheScope"], "public");
 }
 
 fn tool_named<'a>(tools: &'a [Value], name: &str) -> &'a Value {
@@ -2458,25 +2501,49 @@ fn tool_named<'a>(tools: &'a [Value], name: &str) -> &'a Value {
 #[test]
 fn mcp_tools_list_declares_input_schemas() {
     let tempdir = TempDir::new().expect("tempdir");
+    let request = mcp_request(json!(1), "tools/list", json!({}));
     let output = run_kagi_with_stdin(
         &["mcp"],
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n",
+        &format!(
+            "{}\n",
+            serde_json::to_string(&request).expect("request serializes")
+        ),
         &[],
         tempdir.path(),
     );
 
     assert_success(&output);
     let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(response["result"]["cacheScope"], "public");
+    assert_eq!(response["result"]["ttlMs"], 3600000);
     let tools = response["result"]["tools"].as_array().expect("tools array");
 
     for tool in tools {
         let schema = &tool["inputSchema"];
         assert_eq!(schema["type"], "object", "schema type for {tool:?}");
+        assert_eq!(
+            schema["$schema"], "https://json-schema.org/draft/2020-12/schema",
+            "schema dialect for {tool:?}"
+        );
         assert!(
             schema["properties"].is_object(),
             "expected schema properties object for {tool:?}"
         );
     }
+
+    let names: Vec<&str> = tools
+        .iter()
+        .map(|tool| tool["name"].as_str().expect("tool name"))
+        .collect();
+    assert!(
+        names.windows(2).all(|pair| pair[0] < pair[1]),
+        "tools should be returned in deterministic sorted order: {names:?}"
+    );
+    assert_eq!(
+        tool_named(tools, "kagi_search")["annotations"],
+        json!({ "readOnlyHint": true, "openWorldHint": true })
+    );
 
     assert_eq!(
         tool_named(tools, "kagi_search")["inputSchema"]["required"],
@@ -2515,6 +2582,14 @@ fn mcp_tools_list_declares_input_schemas() {
         "expected translate tool"
     );
     assert!(
+        !tools.iter().any(|tool| tool["name"] == "kagi_assistant"),
+        "assistant prompts should not be exposed by default because they create or extend threads"
+    );
+    assert!(
+        !tools.iter().any(|tool| tool["name"] == "kagi_ask_page"),
+        "page questions should not be exposed by default because they create Assistant messages"
+    );
+    assert!(
         !tools.iter().any(|tool| tool["name"] == "kagi_lens_create"),
         "mutating tools should not be exposed by default"
     );
@@ -2523,9 +2598,13 @@ fn mcp_tools_list_declares_input_schemas() {
 #[test]
 fn mcp_tools_list_exposes_mutating_tools_when_enabled() {
     let tempdir = TempDir::new().expect("tempdir");
+    let request = mcp_request(json!(1), "tools/list", json!({}));
     let output = run_kagi_with_stdin(
         &["mcp", "--enable-mutating-tools"],
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n",
+        &format!(
+            "{}\n",
+            serde_json::to_string(&request).expect("request serializes")
+        ),
         &[],
         tempdir.path(),
     );
@@ -2545,14 +2624,63 @@ fn mcp_tools_list_exposes_mutating_tools_when_enabled() {
         tool_named(tools, "kagi_cli").is_object(),
         "expected CLI parity escape hatch when mutating tools are enabled"
     );
+    assert_eq!(
+        tool_named(tools, "kagi_assistant")["annotations"]["readOnlyHint"],
+        false
+    );
+    assert_eq!(
+        tool_named(tools, "kagi_ask_page")["annotations"]["readOnlyHint"],
+        false
+    );
+    assert!(
+        tool_named(tools, "kagi_assistant")["annotations"]
+            .get("destructiveHint")
+            .is_none()
+    );
+    assert_eq!(
+        tool_named(tools, "kagi_lens_create")["annotations"]["readOnlyHint"],
+        false
+    );
+    assert_eq!(
+        tool_named(tools, "kagi_lens_delete")["annotations"]["destructiveHint"],
+        true
+    );
+    assert!(
+        tool_named(tools, "kagi_lens_update")["annotations"]
+            .get("destructiveHint")
+            .is_none()
+    );
+}
+
+#[test]
+fn mcp_tools_list_treats_null_cursor_as_absent() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let request = mcp_request(json!(1), "tools/list", json!({ "cursor": null }));
+    let output = run_kagi_with_stdin(
+        &["mcp"],
+        &format!(
+            "{}\n",
+            serde_json::to_string(&request).expect("request serializes")
+        ),
+        &[],
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
+    assert_eq!(response["result"]["resultType"], "complete");
 }
 
 #[test]
 fn mcp_malformed_json_returns_parse_error_and_keeps_server_alive() {
     let tempdir = TempDir::new().expect("tempdir");
+    let request = mcp_request(json!(2), "server/discover", json!({}));
     let output = run_kagi_with_stdin(
         &["mcp"],
-        "not json\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"initialize\"}\n",
+        &format!(
+            "not json\n{}\n",
+            serde_json::to_string(&request).expect("request serializes")
+        ),
         &[],
         tempdir.path(),
     );
@@ -2567,21 +2695,68 @@ fn mcp_malformed_json_returns_parse_error_and_keeps_server_alive() {
     assert_eq!(responses[0]["id"], Value::Null);
     assert_eq!(responses[0]["error"]["code"], -32700);
     assert_eq!(responses[1]["id"], 2);
-    assert_eq!(responses[1]["result"]["serverInfo"]["name"], "kagi-cli");
+    assert_eq!(
+        responses[1]["result"]["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+        "kagi-cli"
+    );
+}
+
+#[test]
+fn mcp_requires_modern_request_metadata() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let output = run_kagi_with_stdin(
+        &["mcp"],
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}\n",
+        &[],
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
+    assert_eq!(response["error"]["code"], -32602);
+    assert!(
+        response["error"]["message"]
+            .as_str()
+            .expect("error message")
+            .contains("clientCapabilities")
+    );
+}
+
+#[test]
+fn mcp_rejects_unsupported_protocol_versions() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let request = mcp_request_with_version(json!(1), "server/discover", json!({}), "2025-11-25");
+    let output = run_kagi_with_stdin(
+        &["mcp"],
+        &format!(
+            "{}\n",
+            serde_json::to_string(&request).expect("request serializes")
+        ),
+        &[],
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
+    assert_eq!(response["error"]["code"], -32022);
+    assert_eq!(response["error"]["data"]["requested"], "2025-11-25");
+    assert_eq!(
+        response["error"]["data"]["supported"],
+        json!(["2026-07-28"])
+    );
 }
 
 #[test]
 fn mcp_unknown_tool_returns_json_rpc_error() {
     let tempdir = TempDir::new().expect("tempdir");
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_nope",
             "arguments": {}
-        }
-    });
+        }),
+    );
     let mut stdin = serde_json::to_string(&request).expect("request serializes");
     stdin.push('\n');
 
@@ -2590,27 +2765,26 @@ fn mcp_unknown_tool_returns_json_rpc_error() {
     assert_success(&output);
     let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
     assert_eq!(response["id"], 1);
-    assert_eq!(response["error"]["code"], -32000);
+    assert_eq!(response["error"]["code"], -32602);
     assert!(
         response["error"]["message"]
             .as_str()
             .expect("message")
-            .contains("unsupported MCP tool")
+            .contains("Unknown tool")
     );
 }
 
 #[test]
 fn mcp_cli_passthrough_runs_auth_free_commands_when_enabled() {
     let tempdir = TempDir::new().expect("tempdir");
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_cli",
             "arguments": { "args": ["--help"] }
-        }
-    });
+        }),
+    );
     let mut stdin = serde_json::to_string(&request).expect("request serializes");
     stdin.push('\n');
 
@@ -2659,15 +2833,14 @@ fn mcp_cli_passthrough_closes_stdin_when_payload_is_omitted() {
         let _ = tx.send(read.map(|_| line));
     });
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_cli",
             "arguments": { "args": ["batch"] }
-        }
-    });
+        }),
+    );
     writeln!(stdin, "{request}").expect("request should write");
     stdin.flush().expect("request should flush");
 
@@ -2730,15 +2903,28 @@ fn mcp_extract_tool_call_returns_markdown() {
 
     let tempdir = TempDir::new().expect("tempdir");
     let env = test_env(&server);
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
+            "name": "kagi_extract",
+            "arguments": { "url": "https://example.com/article" }
+        }),
+    );
     let output = run_kagi_with_stdin(
         &["mcp"],
-        r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"kagi_extract","arguments":{"url":"https://example.com/article"}}}"#,
+        &format!(
+            "{}\n",
+            serde_json::to_string(&request).expect("request serializes")
+        ),
         &env_refs(&env),
         tempdir.path(),
     );
 
     assert_success(&output);
     let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(response["result"]["isError"], false);
     assert_eq!(
         response["result"]["content"][0]["text"],
         "# Article\n\nExtracted content."
@@ -2779,18 +2965,17 @@ fn mcp_extract_explicit_json_overrides_default_output() {
 
     let tempdir = TempDir::new().expect("tempdir");
     let env = test_env(&server);
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_extract",
             "arguments": {
                 "url": "https://example.com/article",
                 "format": "json"
             }
-        }
-    });
+        }),
+    );
     let mut stdin = serde_json::to_string(&request).expect("request serializes");
     stdin.push('\n');
 
@@ -2809,6 +2994,10 @@ fn mcp_extract_explicit_json_overrides_default_output() {
     let body: Value = serde_json::from_str(text).expect("inner extract should stay JSON");
     assert_eq!(
         body["data"][0]["markdown"],
+        "# Article\n\nExtracted content."
+    );
+    assert_eq!(
+        response["result"]["structuredContent"]["data"][0]["markdown"],
         "# Article\n\nExtracted content."
     );
 }
@@ -2832,15 +3021,14 @@ fn mcp_search_uses_default_output_format() {
 
     let tempdir = TempDir::new().expect("tempdir");
     let env = test_env(&server);
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_search",
             "arguments": { "query": "rust" }
-        }
-    });
+        }),
+    );
     let mut stdin = serde_json::to_string(&request).expect("request serializes");
     stdin.push('\n');
 
@@ -2867,20 +3055,85 @@ fn mcp_search_uses_default_output_format() {
 }
 
 #[test]
+fn mcp_only_exposes_structured_content_for_json_output() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
+            "name": "kagi_history_stats",
+            "arguments": {}
+        }),
+    );
+    let mut stdin = serde_json::to_string(&request).expect("request serializes");
+    stdin.push('\n');
+
+    let output = run_kagi_with_stdin(
+        &["mcp", "--default-output", "pretty"],
+        &stdin,
+        &[],
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
+    let result = &response["result"];
+    assert_eq!(result["isError"], false);
+    let text = result["content"][0]["text"].as_str().expect("text content");
+    serde_json::from_str::<Value>(text).expect("pretty output should remain valid JSON text");
+    assert!(
+        result.get("structuredContent").is_none(),
+        "pretty output must not be duplicated as structured content"
+    );
+}
+
+#[test]
+fn mcp_explicit_json_format_exposes_structured_content_for_news_metadata() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
+            "name": "kagi_news_filter_presets",
+            "arguments": { "format": "json" }
+        }),
+    );
+    let mut stdin = serde_json::to_string(&request).expect("request serializes");
+    stdin.push('\n');
+
+    let output = run_kagi_with_stdin(
+        &["mcp", "--default-output", "pretty"],
+        &stdin,
+        &[],
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
+    let result = &response["result"];
+    assert_eq!(result["isError"], false);
+    let text = result["content"][0]["text"].as_str().expect("text content");
+    serde_json::from_str::<Value>(text).expect("explicit JSON output should parse");
+    assert!(
+        result.get("structuredContent").is_some(),
+        "explicit JSON output must be exposed as structured content"
+    );
+}
+
+#[test]
 fn mcp_batch_search_rejects_zero_concurrency() {
     let tempdir = TempDir::new().expect("tempdir");
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_batch_search",
             "arguments": {
                 "queries": ["rust"],
                 "concurrency": 0
             }
-        }
-    });
+        }),
+    );
     let mut stdin = serde_json::to_string(&request).expect("request serializes");
     stdin.push('\n');
 
@@ -2893,9 +3146,10 @@ fn mcp_batch_search_rejects_zero_concurrency() {
 
     assert_success(&output);
     let response: Value = serde_json::from_slice(&output.stdout).expect("mcp json parses");
-    assert_eq!(response["error"]["code"], -32000);
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(response["result"]["isError"], true);
     assert!(
-        response["error"]["message"]
+        response["result"]["content"][0]["text"]
             .as_str()
             .expect("message")
             .contains("concurrency must be at least 1")
@@ -2965,18 +3219,17 @@ fn mcp_assistant_thread_export_json_overrides_default_output() {
 
     let tempdir = TempDir::new().expect("tempdir");
     let env = session_env(&server);
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_assistant_thread_export",
             "arguments": {
                 "thread_id": "thread-1",
                 "format": "json"
             }
-        }
-    });
+        }),
+    );
     let mut stdin = serde_json::to_string(&request).expect("request serializes");
     stdin.push('\n');
 
@@ -3039,15 +3292,14 @@ fn mcp_news_tool_call_returns_stories() {
 
     let tempdir = TempDir::new().expect("tempdir");
     let env = test_env(&server);
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_news",
             "arguments": { "category": "tech", "lang": "en", "limit": 3 }
-        }
-    });
+        }),
+    );
     let mut stdin = serde_json::to_string(&request).expect("request serializes");
     stdin.push('\n');
 
@@ -3080,19 +3332,18 @@ fn mcp_news_search_tool_call_returns_clusters() {
 
     let tempdir = TempDir::new().expect("tempdir");
     let env = session_env(&server);
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_news_search",
             "arguments": {
                 "query": "iran",
                 "freshness": "day",
                 "order": "recency"
             }
-        }
-    });
+        }),
+    );
     let mut stdin = serde_json::to_string(&request).expect("request serializes");
     stdin.push('\n');
 
@@ -3153,24 +3404,22 @@ fn mcp_tool_call_error_returns_json_rpc_error_and_keeps_server_alive() {
     let env = session_env(&server);
 
     // Send a search tool call (will fail) followed by a news tool call (should succeed).
-    let failing_request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
+    let failing_request = mcp_request(
+        json!(1),
+        "tools/call",
+        json!({
             "name": "kagi_search",
             "arguments": { "query": "test" }
-        }
-    });
-    let succeeding_request = json!({
-        "jsonrpc": "2.0",
-        "id": 2,
-        "method": "tools/call",
-        "params": {
+        }),
+    );
+    let succeeding_request = mcp_request(
+        json!(2),
+        "tools/call",
+        json!({
             "name": "kagi_news",
             "arguments": { "category": "tech", "lang": "en", "limit": 3 }
-        }
-    });
+        }),
+    );
 
     let stdin = format!(
         "{}\n{}\n",
@@ -3189,16 +3438,20 @@ fn mcp_tool_call_error_returns_json_rpc_error_and_keeps_server_alive() {
 
     assert_eq!(responses.len(), 2, "expected two JSON-RPC responses");
 
-    // First response: the failed tool call should be a JSON-RPC error, not a crash.
+    // First response: the failed tool call should be an MCP tool error result, not a crash.
     let error_resp = &responses[0];
     assert_eq!(error_resp["id"], 1);
     assert!(
-        error_resp.get("error").is_some(),
-        "expected JSON-RPC error for failed tool call, got: {error_resp}"
+        error_resp.get("result").is_some(),
+        "expected MCP tool result for failed tool call, got: {error_resp}"
     );
-    assert_eq!(error_resp["error"]["code"], -32000);
+    assert_eq!(error_resp["result"]["resultType"], "complete");
+    assert_eq!(error_resp["result"]["isError"], true);
     assert!(
-        !error_resp["error"]["message"].as_str().unwrap().is_empty(),
+        !error_resp["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .is_empty(),
         "error message should be non-empty"
     );
 


### PR DESCRIPTION
## Summary

- Update `kagi mcp` to MCP `2026-07-28`
- Replace the legacy initialization handshake with `server/discover`
- Require per-request protocol metadata and client capabilities
- Add cache hints, tool annotations, structured content, and modern result types
- Return tool execution failures as `isError: true` results
- Add integration coverage and documentation

## Verification

Automated checks run by OpenAI Codex:

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-targets --locked`
- [x] MCP integration tests: 30 passed

## Docs

- [x] Updated MCP command documentation
- [x] Updated `CHANGELOG.md`

## Auth / Secrets

- [x] No tokens, cookies, or local configuration secrets committed

## AI assistance disclosure

- `agent_name`: OpenAI Codex
- `agent_version`: codex-cli 0.147.0
- `model_used`: GPT-5
- `human_testing`: Maintainer confirmed the listed automated checks were personally run: `cargo fmt --check`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --locked`, and the MCP integration test subset
- `contribution_summary`: Updated the Kagi MCP server for the stateless MCP 2026-07-28 protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated MCP support to protocol version `2026-07-28`.
  * Added server discovery, metadata validation, tool annotations, sorted tool listings, structured JSON results, and response caching metadata.
  * Improved tool visibility controls and clarified read-only and mutating tool behavior.

* **Bug Fixes**
  * Tool execution failures now return completed results marked as errors.
  * Malformed requests, unsupported versions, cursors, and arguments receive clearer protocol errors.
  * Removed the legacy initialization handshake.

* **Documentation**
  * Updated MCP guidance for the latest protocol, request requirements, discovery, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR upgrades the stdio server to the stateless MCP `2026-07-28` protocol and modernizes tool discovery and results.
- Replaces initialization with `server/discover` and validates protocol metadata on each request.
- Adds cache hints, tool annotations, structured JSON content, and completed error results.
- Updates MCP documentation and integration coverage for the new protocol behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main.rs | Implements stateless MCP discovery, metadata validation, annotated tool definitions, modern result handling, and format-aware structured content; both previously reported structured-content defects are resolved. |
| tests/integration-cli.rs | Adds protocol and structured-content integration coverage, including explicit JSON overriding a non-JSON server default. |
| docs/commands/mcp.mdx | Documents the new discovery flow, mandatory request metadata, cache behavior, tool exposure, and result semantics. |
| CHANGELOG.md | Records the MCP protocol upgrade, breaking handshake change, and revised tool-error behavior. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Kagi as kagi mcp
    Client->>Kagi: server/discover + per-request metadata
    Kagi-->>Client: versions, capabilities, cache hints
    Client->>Kagi: tools/list + per-request metadata
    Kagi-->>Client: annotated tool catalog
    Client->>Kagi: tools/call + metadata and arguments
    alt Successful execution
        Kagi-->>Client: complete result + content + optional structuredContent
    else Tool execution failure
        Kagi-->>Client: complete result + isError: true
    else Invalid protocol request
        Kagi-->>Client: JSON-RPC error
    end
```

<sub>Reviews (4): Last reviewed commit: ["feat: update kagi mcp to MCP 2026-07-28"](https://github.com/microck/kagi-cli/commit/7669598b33f037cb8fac6185e2d2088243d8b839) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53164186)</sub>

<!-- /greptile_comment -->