### PR TITLE
fix: use current Assistant API for custom assistants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- `kagi assistant custom` now uses Kagi's current Assistant API, so custom assistant creation no longer fails while parsing the removed settings form.
+
 ## [0.17.0]
 
 ### Changed

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use futures_util::StreamExt;
 use reqwest::multipart;
-use reqwest::{Client, StatusCode, Url, header};
+use reqwest::{Client, Method, StatusCode, Url, header};
 use scraper::Html;
 #[cfg(test)]
 use scraper::Selector;
@@ -25,9 +25,8 @@ use crate::http::{self, map_transport_error};
 #[cfg(test)]
 use crate::parser::parse_assistant_thread_list;
 use crate::parser::{
-    parse_assistant_profile_form, parse_assistant_profile_list, parse_custom_bang_form,
-    parse_custom_bang_list, parse_lens_form, parse_lens_list, parse_redirect_form,
-    parse_redirect_list,
+    parse_custom_bang_form, parse_custom_bang_list, parse_lens_form, parse_lens_list,
+    parse_redirect_form, parse_redirect_list,
 };
 #[cfg(test)]
 use crate::types::ApiMeta;
@@ -64,10 +63,7 @@ const NEWS_FILTER_PRESETS_JSON: &str = include_str!("../data/news-filter-presets
 const DEBUG_BODY_PREVIEW_LIMIT: usize = 256;
 const KAGI_ASSISTANT_CONVERSATIONS_PATH: &str = "/api/conversations";
 const KAGI_ASSISTANT_INIT_PATH: &str = "/api/init";
-const KAGI_SETTINGS_ASSISTANT_PATH: &str = "/html/settings/assistant";
-const KAGI_SETTINGS_CUSTOM_ASSISTANT_PATH: &str = "/settings/custom_assistant";
-const KAGI_SETTINGS_CUSTOM_ASSISTANT_UPDATE_PATH: &str = "/settings/ast/profiles/update";
-const KAGI_SETTINGS_CUSTOM_ASSISTANT_DELETE_PATH: &str = "/settings/ast/profiles/delete";
+const KAGI_ASSISTANTS_PATH: &str = "/api/assistants";
 const KAGI_SETTINGS_LENSES_PATH: &str = "/html/settings/lenses";
 const KAGI_SETTINGS_CREATE_LENS_PATH: &str = "/settings/create_lens";
 const KAGI_LENSES_CREATE_PATH: &str = "/lenses/create";
@@ -1054,13 +1050,8 @@ pub async fn execute_assistant_thread_export(
 pub async fn execute_custom_assistant_list(
     token: &str,
 ) -> Result<Vec<AssistantProfileSummary>, KagiError> {
-    let html = fetch_authenticated_html(
-        &http::kagi_url(KAGI_SETTINGS_ASSISTANT_PATH),
-        token,
-        "Assistant settings page",
-    )
-    .await?;
-    parse_assistant_profile_list(&html)
+    let response = fetch_current_assistant_profiles(token, "Assistant profiles").await?;
+    Ok(response.assistant_summaries())
 }
 
 /// Gets the details of a specific custom assistant profile.
@@ -1078,21 +1069,8 @@ pub async fn execute_custom_assistant_get(
     target: &str,
     token: &str,
 ) -> Result<AssistantProfileDetails, KagiError> {
-    let assistants = execute_custom_assistant_list(token).await?;
-    let assistant = resolve_custom_assistant_ref(&assistants, target, true)?;
-    let edit_url = assistant.edit_url.clone().ok_or_else(|| {
-        KagiError::Config(format!(
-            "assistant '{}' does not expose an editable custom-assistant form",
-            assistant.name
-        ))
-    })?;
-    let html = fetch_authenticated_html(
-        &absolute_kagi_url(&edit_url),
-        token,
-        "custom assistant form",
-    )
-    .await?;
-    parse_assistant_profile_form(&html)
+    let response = fetch_current_assistant_profiles(token, "custom assistant get").await?;
+    Ok(current_custom_assistant_for_target(&response, target)?.details())
 }
 
 /// Creates a new custom assistant profile.
@@ -1110,46 +1088,39 @@ pub async fn execute_custom_assistant_create(
     request: &AssistantProfileCreateRequest,
     token: &str,
 ) -> Result<AssistantProfileDetails, KagiError> {
-    let mut details = parse_assistant_profile_form(
-        &fetch_authenticated_html(
-            &http::kagi_url(KAGI_SETTINGS_CUSTOM_ASSISTANT_PATH),
-            token,
-            "new custom assistant form",
-        )
-        .await?,
-    )?;
-    details.name = normalize_named_target(&request.name, "assistant name")?;
-    if let Some(value) = trimmed_optional(request.bang_trigger.as_deref()) {
-        details.bang_trigger = Some(value.to_string());
-    }
-    if let Some(value) = request.internet_access {
-        details.internet_access = value;
-    }
-    if let Some(value) = trimmed_optional(request.selected_lens.as_deref()) {
-        details.selected_lens = value.to_string();
-    }
-    if let Some(value) = request.personalizations {
-        details.personalizations = value;
-    }
-    if let Some(value) = trimmed_optional(request.base_model.as_deref()) {
-        details.base_model = value.to_string();
-    }
-    if let Some(value) = request.custom_instructions.as_ref() {
-        details.custom_instructions = value.clone();
-    }
-
-    let (url, _) = post_authenticated_form(
-        &http::kagi_url(KAGI_SETTINGS_CUSTOM_ASSISTANT_UPDATE_PATH),
-        &build_custom_assistant_form(&details),
+    let name = normalize_named_target(&request.name, "assistant name")?;
+    let base_model = match trimmed_optional(request.base_model.as_deref()) {
+        Some(value) => value.to_string(),
+        None => {
+            fetch_current_assistant_profiles(token, "Assistant initialization")
+                .await?
+                .models
+                .default
+        }
+    };
+    let details = AssistantProfileDetails {
+        profile_id: None,
+        name,
+        bang_trigger: trimmed_optional(request.bang_trigger.as_deref()).map(str::to_string),
+        internet_access: request.internet_access.unwrap_or(true),
+        selected_lens: trimmed_optional(request.selected_lens.as_deref())
+            .unwrap_or_default()
+            .to_string(),
+        personalizations: request.personalizations.unwrap_or(false),
+        base_model,
+        custom_instructions: request.custom_instructions.clone().unwrap_or_default(),
+        delete_supported: true,
+    };
+    let created = send_current_assistant_json::<CurrentAssistantCustomAssistant>(
+        Method::POST,
+        KAGI_ASSISTANTS_PATH,
+        &current_assistant_profile_payload(&details),
         token,
         "custom assistant create",
     )
     .await?;
-    let created_id = match url_query_value(&url, "id") {
-        Some(id) => id,
-        None => resolve_custom_assistant_id_by_name(&details.name, token).await?,
-    };
-    execute_custom_assistant_get(&created_id, token).await
+
+    Ok(created.details())
 }
 
 /// Updates an existing custom assistant profile.
@@ -1167,39 +1138,51 @@ pub async fn execute_custom_assistant_update(
     request: &AssistantProfileUpdateRequest,
     token: &str,
 ) -> Result<AssistantProfileDetails, KagiError> {
-    let assistants = execute_custom_assistant_list(token).await?;
-    let assistant = resolve_custom_assistant_ref(&assistants, &request.target, true)?;
-    let mut details = execute_custom_assistant_get(&assistant.id, token).await?;
-    if let Some(value) = request.name.as_deref() {
-        details.name = normalize_named_target(value, "assistant name")?;
-    }
-    if let Some(value) = request.bang_trigger.as_deref() {
-        details.bang_trigger = trimmed_optional(Some(value)).map(str::to_string);
-    }
-    if let Some(value) = request.internet_access {
-        details.internet_access = value;
-    }
-    if let Some(value) = trimmed_optional(request.selected_lens.as_deref()) {
-        details.selected_lens = value.to_string();
-    }
-    if let Some(value) = request.personalizations {
-        details.personalizations = value;
-    }
-    if let Some(value) = trimmed_optional(request.base_model.as_deref()) {
-        details.base_model = value.to_string();
-    }
-    if let Some(value) = request.custom_instructions.as_ref() {
-        details.custom_instructions = value.clone();
-    }
-
-    post_authenticated_form(
-        &http::kagi_url(KAGI_SETTINGS_CUSTOM_ASSISTANT_UPDATE_PATH),
-        &build_custom_assistant_form(&details),
+    let response = fetch_current_assistant_profiles(token, "custom assistant update").await?;
+    let assistant = current_custom_assistant_for_target(&response, &request.target)?;
+    let name = match request.name.as_deref() {
+        Some(value) => normalize_named_target(value, "assistant name")?,
+        None => assistant.name.clone(),
+    };
+    let bang_trigger = match request.bang_trigger.as_deref() {
+        Some(value) => trimmed_optional(Some(value)).map(str::to_string),
+        None => assistant.bang_trigger.clone(),
+    };
+    let selected_lens = match request.selected_lens.as_deref() {
+        Some(value) => trimmed_optional(Some(value)).map(str::to_string),
+        None => assistant.lens_id.clone(),
+    };
+    let custom_instructions = match request.custom_instructions.as_deref() {
+        Some("") => None,
+        Some(value) => Some(value.to_string()),
+        None => assistant.instructions.clone(),
+    };
+    let base_model = trimmed_optional(request.base_model.as_deref())
+        .map(str::to_string)
+        .unwrap_or_else(|| assistant.llm_id.clone());
+    let details = AssistantProfileDetails {
+        profile_id: Some(assistant.uuid.clone()),
+        name,
+        bang_trigger,
+        internet_access: request.internet_access.unwrap_or(assistant.internet_access),
+        selected_lens: selected_lens.unwrap_or_default(),
+        personalizations: request
+            .personalizations
+            .unwrap_or(assistant.personalizations),
+        base_model,
+        custom_instructions: custom_instructions.unwrap_or_default(),
+        delete_supported: true,
+    };
+    let updated = send_current_assistant_json::<CurrentAssistantCustomAssistant>(
+        Method::PATCH,
+        &format!("{KAGI_ASSISTANTS_PATH}/{}", assistant.uuid),
+        &current_assistant_profile_payload(&details),
         token,
         "custom assistant update",
     )
     .await?;
-    execute_custom_assistant_get(&assistant.id, token).await
+
+    Ok(updated.details())
 }
 
 /// Deletes a custom assistant profile.
@@ -1217,17 +1200,16 @@ pub async fn execute_custom_assistant_delete(
     target: &str,
     token: &str,
 ) -> Result<DeletedResourceResponse, KagiError> {
-    let assistants = execute_custom_assistant_list(token).await?;
-    let assistant = resolve_custom_assistant_ref(&assistants, target, true)?;
-    post_authenticated_form(
-        &http::kagi_url(KAGI_SETTINGS_CUSTOM_ASSISTANT_DELETE_PATH),
-        &[("profile_id".to_string(), assistant.id.clone())],
+    let response = fetch_current_assistant_profiles(token, "custom assistant delete").await?;
+    let assistant = current_custom_assistant_for_target(&response, target)?;
+    delete_current_assistant_resource(
+        &format!("{KAGI_ASSISTANTS_PATH}/{}", assistant.uuid),
         token,
         "custom assistant delete",
     )
     .await?;
     Ok(DeletedResourceResponse {
-        id: assistant.id.clone(),
+        id: assistant.uuid.clone(),
     })
 }
 
@@ -2938,42 +2920,6 @@ fn url_query_value(url: &Url, key: &str) -> Option<String> {
         .map(|(_, value)| value.into_owned())
 }
 
-fn build_custom_assistant_form(details: &AssistantProfileDetails) -> Vec<(String, String)> {
-    vec![
-        (
-            "profile_id".to_string(),
-            details.profile_id.clone().unwrap_or_default(),
-        ),
-        ("name".to_string(), details.name.clone()),
-        (
-            "bang_trigger".to_string(),
-            details.bang_trigger.clone().unwrap_or_default(),
-        ),
-        (
-            "internet_access".to_string(),
-            if details.internet_access {
-                "on".to_string()
-            } else {
-                "false".to_string()
-            },
-        ),
-        ("selected_lens".to_string(), details.selected_lens.clone()),
-        (
-            "personalizations".to_string(),
-            if details.personalizations {
-                "on".to_string()
-            } else {
-                "false".to_string()
-            },
-        ),
-        ("base_model".to_string(), details.base_model.clone()),
-        (
-            "custom_instructions".to_string(),
-            details.custom_instructions.clone(),
-        ),
-    ]
-}
-
 fn build_lens_form(details: &LensDetails) -> Vec<(String, String)> {
     let mut form = vec![
         ("name".to_string(), details.name.clone()),
@@ -3308,6 +3254,40 @@ fn resolve_custom_assistant_ref<'a>(
     Ok(assistant)
 }
 
+fn current_custom_assistant_for_target<'a>(
+    response: &'a CurrentAssistantInitResponse,
+    target: &str,
+) -> Result<&'a CurrentAssistantCustomAssistant, KagiError> {
+    let assistant_id = resolve_custom_assistant_ref(&response.assistant_summaries(), target, true)?
+        .id
+        .clone();
+    response
+        .custom_assistants
+        .iter()
+        .find(|assistant| assistant.uuid == assistant_id)
+        .ok_or_else(|| {
+            KagiError::Parse(format!(
+                "custom assistant '{}' was listed without a definition",
+                assistant_id
+            ))
+        })
+}
+
+fn current_assistant_profile_payload(details: &AssistantProfileDetails) -> Value {
+    let instructions =
+        (!details.custom_instructions.is_empty()).then_some(details.custom_instructions.as_str());
+    let selected_lens = trimmed_optional(Some(&details.selected_lens));
+    json!({
+        "name": details.name,
+        "llm_id": details.base_model,
+        "instructions": instructions,
+        "internet_access": details.internet_access,
+        "personalizations": details.personalizations,
+        "lens_id": selected_lens,
+        "bang_trigger": details.bang_trigger,
+    })
+}
+
 fn resolve_lens_ref<'a>(
     lenses: &'a [LensSummary],
     target: &str,
@@ -3431,11 +3411,6 @@ fn resolve_redirect_ref<'a>(
         .iter()
         .find(|redirect| redirect.id == target || redirect.rule == target)
         .ok_or_else(|| KagiError::Config(format!("no redirect matched '{target}'")))
-}
-
-async fn resolve_custom_assistant_id_by_name(name: &str, token: &str) -> Result<String, KagiError> {
-    let assistants = execute_custom_assistant_list(token).await?;
-    resolve_custom_assistant_ref(&assistants, name, true).map(|assistant| assistant.id.clone())
 }
 
 async fn resolve_lens_id_by_name(name: &str, token: &str) -> Result<String, KagiError> {
@@ -3593,6 +3568,37 @@ where
         .get(http::kagi_assistant_url(path))
         .header(header::COOKIE, format!("kagi_session={token}"))
         .header(header::ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(map_transport_error)?;
+
+    read_current_assistant_json_response(response, surface).await
+}
+
+async fn fetch_current_assistant_profiles(
+    token: &str,
+    surface: &str,
+) -> Result<CurrentAssistantInitResponse, KagiError> {
+    fetch_current_assistant_json(KAGI_ASSISTANT_INIT_PATH, token, surface).await
+}
+
+async fn send_current_assistant_json<T>(
+    method: Method,
+    path: &str,
+    payload: &Value,
+    token: &str,
+    surface: &str,
+) -> Result<T, KagiError>
+where
+    T: DeserializeOwned,
+{
+    let client = build_client()?;
+    let response = client
+        .request(method, http::kagi_assistant_url(path))
+        .header(header::COOKIE, format!("kagi_session={token}"))
+        .header(header::ACCEPT, "application/json")
+        .header(header::CONTENT_TYPE, "application/json")
+        .json(payload)
         .send()
         .await
         .map_err(map_transport_error)?;
@@ -4855,12 +4861,33 @@ struct CurrentAssistantConversationInitResponse {
 #[derive(Debug, Deserialize)]
 struct CurrentAssistantInitResponse {
     models: CurrentAssistantModelCatalog,
+    #[serde(default)]
+    custom_assistants: Vec<CurrentAssistantCustomAssistant>,
+}
+
+impl CurrentAssistantInitResponse {
+    fn assistant_summaries(&self) -> Vec<AssistantProfileSummary> {
+        let mut assistants = self
+            .models
+            .assistants
+            .iter()
+            .map(|assistant| assistant.summary(&self.models))
+            .collect::<Vec<_>>();
+        assistants.extend(
+            self.custom_assistants
+                .iter()
+                .map(|assistant| assistant.summary(&self.models)),
+        );
+        assistants
+    }
 }
 
 #[derive(Debug, Deserialize)]
 struct CurrentAssistantModelCatalog {
     models: Vec<CurrentAssistantModel>,
     default: String,
+    #[serde(default)]
+    assistants: Vec<CurrentAssistantBuiltinAssistant>,
 }
 
 impl From<CurrentAssistantModelCatalog> for AssistantModelCatalog {
@@ -4884,6 +4911,89 @@ impl From<CurrentAssistantModel> for AssistantModelOption {
             id: model.id,
             label: model.display_name,
         }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CurrentAssistantBuiltinAssistant {
+    id: String,
+    name: String,
+    #[serde(default)]
+    underlying_model: String,
+    internet_access: bool,
+}
+
+impl CurrentAssistantBuiltinAssistant {
+    fn summary(&self, models: &CurrentAssistantModelCatalog) -> AssistantProfileSummary {
+        let invoke_profile = self
+            .id
+            .strip_prefix("assistant:")
+            .unwrap_or(&self.id)
+            .to_string();
+        AssistantProfileSummary {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            invoke_profile,
+            model: models.model_label(&self.underlying_model),
+            bang_trigger: None,
+            internet_access: self.internet_access,
+            built_in: true,
+            edit_url: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CurrentAssistantCustomAssistant {
+    uuid: String,
+    name: String,
+    #[serde(default)]
+    bang_trigger: Option<String>,
+    #[serde(default)]
+    instructions: Option<String>,
+    internet_access: bool,
+    personalizations: bool,
+    #[serde(default)]
+    lens_id: Option<String>,
+    llm_id: String,
+}
+
+impl CurrentAssistantCustomAssistant {
+    fn summary(&self, models: &CurrentAssistantModelCatalog) -> AssistantProfileSummary {
+        AssistantProfileSummary {
+            id: self.uuid.clone(),
+            name: self.name.clone(),
+            invoke_profile: self.uuid.clone(),
+            model: models.model_label(&self.llm_id),
+            bang_trigger: self.bang_trigger.clone(),
+            internet_access: self.internet_access,
+            built_in: false,
+            edit_url: Some(format!("{KAGI_ASSISTANTS_PATH}/{}", self.uuid)),
+        }
+    }
+
+    fn details(&self) -> AssistantProfileDetails {
+        AssistantProfileDetails {
+            profile_id: Some(self.uuid.clone()),
+            name: self.name.clone(),
+            bang_trigger: self.bang_trigger.clone(),
+            internet_access: self.internet_access,
+            selected_lens: self.lens_id.clone().unwrap_or_default(),
+            personalizations: self.personalizations,
+            base_model: self.llm_id.clone(),
+            custom_instructions: self.instructions.clone().unwrap_or_default(),
+            delete_supported: true,
+        }
+    }
+}
+
+impl CurrentAssistantModelCatalog {
+    fn model_label(&self, model_id: &str) -> String {
+        self.models
+            .iter()
+            .find(|model| model.id == model_id)
+            .map(|model| model.display_name.clone())
+            .unwrap_or_else(|| model_id.to_string())
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -64,6 +64,7 @@ const DEBUG_BODY_PREVIEW_LIMIT: usize = 256;
 const KAGI_ASSISTANT_CONVERSATIONS_PATH: &str = "/api/conversations";
 const KAGI_ASSISTANT_INIT_PATH: &str = "/api/init";
 const KAGI_ASSISTANTS_PATH: &str = "/api/assistants";
+const KAGI_ASSISTANT_CUSTOM_EDITOR_PATH: &str = "/assistant/custom-assistants";
 const KAGI_SETTINGS_LENSES_PATH: &str = "/html/settings/lenses";
 const KAGI_SETTINGS_CREATE_LENS_PATH: &str = "/settings/create_lens";
 const KAGI_LENSES_CREATE_PATH: &str = "/lenses/create";
@@ -1106,7 +1107,7 @@ pub async fn execute_custom_assistant_create(
         selected_lens: trimmed_optional(request.selected_lens.as_deref())
             .unwrap_or_default()
             .to_string(),
-        personalizations: request.personalizations.unwrap_or(false),
+        personalizations: request.personalizations.unwrap_or(true),
         base_model,
         custom_instructions: request.custom_instructions.clone().unwrap_or_default(),
         delete_supported: true,
@@ -4968,7 +4969,7 @@ impl CurrentAssistantCustomAssistant {
             bang_trigger: self.bang_trigger.clone(),
             internet_access: self.internet_access,
             built_in: false,
-            edit_url: Some(format!("{KAGI_ASSISTANTS_PATH}/{}", self.uuid)),
+            edit_url: Some(format!("{KAGI_ASSISTANT_CUSTOM_EDITOR_PATH}/{}", self.uuid)),
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2111,6 +2111,45 @@ mod tests {
     }
 
     #[test]
+    fn parses_assistant_custom_create_command() {
+        let cli = Cli::try_parse_from([
+            "kagi",
+            "assistant",
+            "custom",
+            "create",
+            "Release Notes",
+            "--model",
+            "gpt-5-4-nano",
+            "--web-access",
+            "--lens",
+            "2",
+            "--instructions",
+            "Focus on release diffs and migration notes.",
+        ])
+        .expect("assistant custom create should parse");
+
+        match cli.command.expect("command") {
+            Commands::Assistant(args) => match args.command.expect("subcommand") {
+                super::AssistantSubcommand::Custom(custom) => match custom.command {
+                    super::AssistantCustomSubcommand::Create(create) => {
+                        assert_eq!(create.name, "Release Notes");
+                        assert_eq!(create.model.as_deref(), Some("gpt-5-4-nano"));
+                        assert!(create.web_access);
+                        assert_eq!(create.lens.as_deref(), Some("2"));
+                        assert_eq!(
+                            create.instructions.as_deref(),
+                            Some("Focus on release diffs and migration notes.")
+                        );
+                    }
+                    other => panic!("unexpected assistant custom subcommand: {other:?}"),
+                },
+                other => panic!("unexpected assistant subcommand: {other:?}"),
+            },
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
     fn parses_assistant_custom_update_command() {
         let cli = Cli::try_parse_from([
             "kagi",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,8 @@
 //! HTML parsing for Kagi search result pages.
 //!
 //! Extracts structured [`SearchResult`] values from the HTML markup returned
-//! by Kagi's web search endpoint. Also parses assistant profiles, threads,
-//! custom bangs, and lens details from their respective HTML pages.
+//! by Kagi's web search endpoint. Also parses assistant threads, custom
+//! bangs, and lens details from their respective HTML pages.
 
 use std::collections::HashSet;
 
@@ -12,9 +12,8 @@ use crate::error::KagiError;
 #[cfg(test)]
 use crate::types::AssistantThreadSummary;
 use crate::types::{
-    AssistantProfileDetails, AssistantProfileSummary, CustomBangDetails, CustomBangSummary,
-    LensDetails, LensSummary, NewsSearchCluster, NewsSearchResult, RedirectRuleDetails,
-    RedirectRuleSummary, SearchResult,
+    CustomBangDetails, CustomBangSummary, LensDetails, LensSummary, NewsSearchCluster,
+    NewsSearchResult, RedirectRuleDetails, RedirectRuleSummary, SearchResult,
 };
 
 /// Parse Kagi search results from HTML.
@@ -261,129 +260,6 @@ pub fn parse_assistant_thread_list(html: &str) -> Result<Vec<AssistantThreadSumm
     }
 
     Ok(threads)
-}
-
-/// Parses a list of assistant profiles from the Kagi settings HTML.
-///
-/// # Arguments
-/// * `html` - The HTML content of the assistant profiles page.
-///
-/// # Returns
-/// A vector of `AssistantProfileSummary` entries.
-///
-/// # Errors
-/// Returns `KagiError::Parse` if expected elements or attributes are missing.
-pub fn parse_assistant_profile_list(html: &str) -> Result<Vec<AssistantProfileSummary>, KagiError> {
-    let document = Html::parse_document(html);
-    let item_selector = selector("#custom_mode_table #items_p .item")?;
-    let name_selector = selector(".item-name a")?;
-    let edit_selector = selector(".edit a")?;
-    let detail_block_selector = selector(".item-details > div")?;
-    let dd_selector = selector("dd")?;
-
-    let mut assistants = Vec::new();
-
-    for item in document.select(&item_selector) {
-        let id = item
-            .value()
-            .attr("id")
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| KagiError::Parse("assistant item missing id".to_string()))?
-            .to_string();
-
-        let anchor = item
-            .select(&name_selector)
-            .next()
-            .ok_or_else(|| KagiError::Parse("assistant item missing name link".to_string()))?;
-        let name = anchor.text().collect::<String>().trim().to_string();
-        let href = anchor
-            .value()
-            .attr("href")
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| KagiError::Parse("assistant item missing invoke link".to_string()))?;
-
-        let detail_blocks = item.select(&detail_block_selector).collect::<Vec<_>>();
-        let model = detail_blocks
-            .first()
-            .and_then(|block| block.select(&dd_selector).next())
-            .map(|node| node.text().collect::<String>().trim().to_string())
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| KagiError::Parse(format!("assistant '{name}' missing model")))?;
-        let bang_trigger = detail_blocks
-            .get(1)
-            .map(|block| block.text().collect::<String>().trim().to_string())
-            .filter(|value| !value.is_empty());
-        let internet_access = detail_blocks
-            .last()
-            .and_then(|block| block.select(&dd_selector).next())
-            .map(|node| node.text().collect::<String>())
-            .is_some_and(|value| parse_toggle_text(&value));
-        let edit_url = item
-            .select(&edit_selector)
-            .next()
-            .and_then(|node| node.value().attr("href"))
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string);
-        let invoke_profile = parse_query_value(href, "profile").unwrap_or_else(|| id.clone());
-
-        assistants.push(AssistantProfileSummary {
-            id,
-            name,
-            invoke_profile,
-            model,
-            bang_trigger,
-            internet_access,
-            built_in: edit_url.is_none(),
-            edit_url,
-        });
-    }
-
-    Ok(assistants)
-}
-
-/// Parses the assistant profile edit form from HTML to extract field values.
-///
-/// # Arguments
-/// * `html` - The HTML content of the assistant profile form.
-///
-/// # Returns
-/// An `AssistantProfileDetails` with all form field values.
-///
-/// # Errors
-/// Returns `KagiError::Parse` if required fields are missing from the form.
-pub fn parse_assistant_profile_form(html: &str) -> Result<AssistantProfileDetails, KagiError> {
-    let document = Html::parse_document(html);
-    let profile_id = extract_input_value(&document, "profile_id");
-    let name = extract_input_value(&document, "name")
-        .ok_or_else(|| KagiError::Parse("assistant form missing name".to_string()))?;
-    let bang_trigger =
-        extract_input_value(&document, "bang_trigger").filter(|value| !value.is_empty());
-    let selected_lens = extract_checked_radio_value(&document, "selected_lens")
-        .ok_or_else(|| KagiError::Parse("assistant form missing selected lens".to_string()))?;
-    let base_model = extract_checked_radio_value(&document, "base_model").unwrap_or_default();
-    let custom_instructions =
-        extract_textarea_value(&document, "custom_instructions").unwrap_or_default();
-    let delete_supported = document
-        .select(&selector(
-            r#"form[action="/settings/ast/profiles/delete"]"#,
-        )?)
-        .next()
-        .is_some();
-
-    Ok(AssistantProfileDetails {
-        profile_id,
-        name,
-        bang_trigger,
-        internet_access: extract_checkbox_checked(&document, "internet_access"),
-        selected_lens,
-        personalizations: extract_checkbox_checked(&document, "personalizations"),
-        base_model,
-        custom_instructions,
-        delete_supported,
-    })
 }
 
 /// Parses a list of Kagi lenses from the settings HTML.
@@ -704,14 +580,6 @@ fn extract_input_value(document: &Html, name: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-fn extract_textarea_value(document: &Html, name: &str) -> Option<String> {
-    let selector = selector(&format!(r#"textarea[name="{name}"]"#)).ok()?;
-    document
-        .select(&selector)
-        .next()
-        .map(|node| node.text().collect::<String>())
-}
-
 fn extract_checked_radio_value(document: &Html, name: &str) -> Option<String> {
     let selector = selector(&format!(r#"input[type="radio"][name="{name}"]"#)).ok()?;
     document.select(&selector).find_map(|node| {
@@ -775,9 +643,9 @@ fn parse_query_value(href: &str, key: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_assistant_profile_form, parse_assistant_profile_list, parse_assistant_thread_list,
-        parse_custom_bang_form, parse_custom_bang_list, parse_lens_form, parse_lens_list,
-        parse_news_search_results, parse_redirect_form, parse_redirect_list, parse_search_results,
+        parse_assistant_thread_list, parse_custom_bang_form, parse_custom_bang_list,
+        parse_lens_form, parse_lens_list, parse_news_search_results, parse_redirect_form,
+        parse_redirect_list, parse_search_results,
     };
     use crate::error::KagiError;
 
@@ -876,107 +744,6 @@ mod tests {
 
         assert!(matches!(error, KagiError::Parse(_)));
         assert!(error.to_string().contains("missing data-code"));
-    }
-
-    #[test]
-    fn parses_assistant_profile_list_items() {
-        let html = r#"
-        <div id="custom_mode_table">
-          <ul id="items_p">
-            <li class="item" id="profile-1">
-              <div class="item-name">
-                <a href="/assistant?profile=code">Code</a>
-              </div>
-              <dl class="item-details">
-                <div><dt>Model:</dt><dd>Quick</dd></div>
-                <div></div>
-                <div><dt>Internet Access:</dt><dd>On</dd></div>
-              </dl>
-            </li>
-            <li class="item" id="profile-2">
-              <div class="item-name">
-                <a href="/assistant?profile=profile-2">Writer</a>
-              </div>
-              <dl class="item-details">
-                <div><dt>Model:</dt><dd>GPT 5 Mini</dd></div>
-                <div>!write</div>
-                <div><dt>Internet Access:</dt><dd>Off</dd></div>
-              </dl>
-              <div class="edit">
-                <a href="/settings/custom_assistant?id=profile-2">Edit</a>
-              </div>
-            </li>
-          </ul>
-        </div>
-        "#;
-
-        let assistants = parse_assistant_profile_list(html).expect("assistant list should parse");
-
-        assert_eq!(assistants.len(), 2);
-        assert_eq!(assistants[0].invoke_profile, "code");
-        assert!(assistants[0].built_in);
-        assert_eq!(assistants[1].bang_trigger.as_deref(), Some("!write"));
-        assert!(!assistants[1].internet_access);
-        assert_eq!(
-            assistants[1].edit_url.as_deref(),
-            Some("/settings/custom_assistant?id=profile-2")
-        );
-    }
-
-    #[test]
-    fn parses_assistant_profile_form_fields() {
-        let html = r#"
-        <form class="s-form" action="/settings/ast/profiles/update" method="POST">
-          <input type="hidden" name="profile_id" value="profile-2">
-          <input type="text" name="name" value="Writer">
-          <input type="text" name="bang_trigger" value="write">
-          <input type="checkbox" name="internet_access" checked value="on">
-          <input type="hidden" name="internet_access" value="false">
-          <input type="radio" name="selected_lens" value="0" class="hidden">
-          <input type="radio" name="selected_lens" value="15" checked class="hidden">
-          <input type="checkbox" name="personalizations" value="on">
-          <input type="hidden" name="personalizations" value="false">
-          <input type="radio" name="base_model" value="gpt-5-mini" checked class="hidden">
-          <textarea name="custom_instructions">Write clearly.</textarea>
-        </form>
-        <form action="/settings/ast/profiles/delete" method="POST"></form>
-        "#;
-
-        let details = parse_assistant_profile_form(html).expect("assistant form should parse");
-
-        assert_eq!(details.profile_id.as_deref(), Some("profile-2"));
-        assert_eq!(details.name, "Writer");
-        assert_eq!(details.bang_trigger.as_deref(), Some("write"));
-        assert!(details.internet_access);
-        assert_eq!(details.selected_lens, "15");
-        assert!(!details.personalizations);
-        assert_eq!(details.base_model, "gpt-5-mini");
-        assert_eq!(details.custom_instructions, "Write clearly.");
-        assert!(details.delete_supported);
-    }
-
-    #[test]
-    fn allows_custom_assistant_create_form_without_selected_model() {
-        let html = r#"
-        <form class="s-form" action="/settings/ast/profiles/update" method="POST">
-          <input type="hidden" name="profile_id" value="">
-          <input type="text" name="name" value="">
-          <input type="text" name="bang_trigger" value="">
-          <input type="checkbox" name="internet_access" checked value="on">
-          <input type="hidden" name="internet_access" value="false">
-          <input type="radio" name="selected_lens" value="0" checked class="hidden">
-          <input type="checkbox" name="personalizations" checked value="on">
-          <input type="hidden" name="personalizations" value="false">
-          <input type="radio" name="base_model" value="gpt-5-mini" class="hidden">
-          <textarea name="custom_instructions"></textarea>
-        </form>
-        "#;
-
-        let details = parse_assistant_profile_form(html).expect("create form should parse");
-
-        assert_eq!(details.base_model, "");
-        assert!(details.internet_access);
-        assert_eq!(details.selected_lens, "0");
     }
 
     #[test]

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -2129,6 +2129,7 @@ fn assistant_custom_create_uses_current_assistant_api() {
             .body_includes("\"name\":\"Release Notes\"")
             .body_includes("\"llm_id\":\"gpt-5-4-nano\"")
             .body_includes("\"internet_access\":true")
+            .body_includes("\"personalizations\":true")
             .body_includes("\"lens_id\":\"2\"")
             .body_includes("\"instructions\":\"Focus on release diffs and migration notes.\"");
         then.status(200).json_body(custom_assistant_json(
@@ -2303,6 +2304,10 @@ fn assistant_resolves_name_to_profile_uuid() {
     let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
     assert_eq!(body["message"]["profile"]["id"], "profile-once");
     assert_eq!(body["message"]["profile"]["name"], "Once");
+    assert_eq!(
+        body["message"]["profile"]["edit_url"],
+        "/assistant/custom-assistants/profile-once"
+    );
 }
 
 #[test]
@@ -2421,7 +2426,8 @@ fn assistant_once_creates_prompts_and_deletes_temporary_profile() {
         when.method(POST)
             .path("/api/assistants")
             .header("cookie", "kagi_session=test-session")
-            .body_includes("\"llm_id\":\"gpt-5-mini\"");
+            .body_includes("\"llm_id\":\"gpt-5-mini\"")
+            .body_includes("\"personalizations\":true");
         then.status(200)
             .json_body(custom_assistant_json("profile-once", "Once", "gpt-5-mini"));
     });

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -5,7 +5,7 @@ use std::process::{Command, Output, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
 
-use httpmock::Method::{GET, POST};
+use httpmock::Method::{DELETE, GET, PATCH, POST};
 use httpmock::MockServer;
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -396,47 +396,36 @@ fn api_meta() -> Value {
     })
 }
 
-fn assistant_form_html(profile_id: &str, name: &str) -> String {
-    format!(
-        r#"
-        <form class="s-form" action="/settings/ast/profiles/update" method="POST">
-          <input type="hidden" name="profile_id" value="{profile_id}">
-          <input type="text" name="name" value="{name}">
-          <input type="text" name="bang_trigger" value="">
-          <input type="checkbox" name="internet_access" checked value="on">
-          <input type="hidden" name="internet_access" value="false">
-          <input type="radio" name="selected_lens" value="0" checked class="hidden">
-          <input type="checkbox" name="personalizations" checked value="on">
-          <input type="hidden" name="personalizations" value="false">
-          <input type="radio" name="base_model" value="gpt-5-mini" aria-label="GPT 5 Mini" checked class="hidden">
-          <input type="radio" name="base_model" value="claude-4-7-opus" aria-label="Claude Opus" class="hidden">
-          <textarea name="custom_instructions"></textarea>
-        </form>
-        <form action="/settings/ast/profiles/delete" method="POST"></form>
-        "#
-    )
+fn assistant_init_json(custom_assistants: Value) -> Value {
+    json!({
+        "models": {
+            "models": [{
+                "id": "gpt-5-mini",
+                "display_name": "GPT 5 Mini"
+            }],
+            "default": "gpt-5-mini",
+            "assistants": [{
+                "id": "assistant:code",
+                "name": "Code",
+                "underlying_model": "gpt-5-mini",
+                "internet_access": true
+            }]
+        },
+        "custom_assistants": custom_assistants
+    })
 }
 
-fn assistant_list_html() -> &'static str {
-    r#"
-    <div id="custom_mode_table">
-      <ul id="items_p">
-        <li class="item" id="profile-once">
-          <div class="item-name">
-            <a href="/assistant?profile=profile-once">Once</a>
-          </div>
-          <dl class="item-details">
-            <div><dt>Model:</dt><dd>GPT 5 Mini</dd></div>
-            <div></div>
-            <div><dt>Internet Access:</dt><dd>On</dd></div>
-          </dl>
-          <div class="edit">
-            <a href="/settings/custom_assistant?id=profile-once">Edit</a>
-          </div>
-        </li>
-      </ul>
-    </div>
-    "#
+fn custom_assistant_json(id: &str, name: &str, model: &str) -> Value {
+    json!({
+        "uuid": id,
+        "name": name,
+        "llm_id": model,
+        "instructions": "",
+        "internet_access": true,
+        "personalizations": false,
+        "lens_id": null,
+        "bang_trigger": null
+    })
 }
 
 fn mock_current_assistant_prompt<'a>(
@@ -2130,6 +2119,119 @@ fn assistant_models_prints_json_catalog() {
 }
 
 #[test]
+fn assistant_custom_create_uses_current_assistant_api() {
+    let server = MockServer::start();
+    let _create = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/assistants")
+            .header("cookie", "kagi_session=test-session")
+            .header("content-type", "application/json")
+            .body_includes("\"name\":\"Release Notes\"")
+            .body_includes("\"llm_id\":\"gpt-5-4-nano\"")
+            .body_includes("\"internet_access\":true")
+            .body_includes("\"lens_id\":\"2\"")
+            .body_includes("\"instructions\":\"Focus on release diffs and migration notes.\"");
+        then.status(200).json_body(custom_assistant_json(
+            "profile-release-notes",
+            "Release Notes",
+            "gpt-5-4-nano",
+        ));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = session_env(&server);
+    let output = run_kagi(
+        &[
+            "assistant",
+            "custom",
+            "create",
+            "Release Notes",
+            "--model",
+            "gpt-5-4-nano",
+            "--web-access",
+            "--lens",
+            "2",
+            "--instructions",
+            "Focus on release diffs and migration notes.",
+        ],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["profile_id"], "profile-release-notes");
+    assert_eq!(body["name"], "Release Notes");
+    assert_eq!(body["base_model"], "gpt-5-4-nano");
+}
+
+#[test]
+fn assistant_custom_update_uses_current_assistant_api() {
+    let server = MockServer::start();
+    let _profiles = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/init")
+            .header("cookie", "kagi_session=test-session");
+        then.status(200)
+            .json_body(assistant_init_json(json!([custom_assistant_json(
+                "profile-writer",
+                "Writer",
+                "gpt-5-mini"
+            )])));
+    });
+    let _update = server.mock(|when, then| {
+        when.method(PATCH)
+            .path("/api/assistants/profile-writer")
+            .header("cookie", "kagi_session=test-session")
+            .header("content-type", "application/json")
+            .body_includes("\"name\":\"Release Notes\"")
+            .body_includes("\"llm_id\":\"gpt-5-4-nano\"")
+            .body_includes("\"internet_access\":false")
+            .body_includes("\"lens_id\":\"2\"")
+            .body_includes("\"instructions\":\"Use migration notes.\"");
+        then.status(200).json_body(json!({
+            "uuid": "profile-writer",
+            "name": "Release Notes",
+            "llm_id": "gpt-5-4-nano",
+            "instructions": "Use migration notes.",
+            "internet_access": false,
+            "personalizations": false,
+            "lens_id": "2",
+            "bang_trigger": null
+        }));
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = session_env(&server);
+    let output = run_kagi(
+        &[
+            "assistant",
+            "custom",
+            "update",
+            "Writer",
+            "--name",
+            "Release Notes",
+            "--model",
+            "gpt-5-4-nano",
+            "--no-web-access",
+            "--lens",
+            "2",
+            "--instructions",
+            "Use migration notes.",
+        ],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["profile_id"], "profile-writer");
+    assert_eq!(body["name"], "Release Notes");
+    assert_eq!(body["internet_access"], false);
+    assert_eq!(body["selected_lens"], "2");
+}
+
+#[test]
 fn assistant_stream_prints_text_deltas_by_default() {
     let server = MockServer::start();
     mock_current_assistant_prompt(&server, "Hello", Some("Hel"), "Hello", None);
@@ -2179,9 +2281,14 @@ fn assistant_resolves_name_to_profile_uuid() {
         mock_current_assistant_prompt(&server, "Hello", None, "Hello", Some("profile-once"));
     let _profiles = server.mock(|when, then| {
         when.method(GET)
-            .path("/html/settings/assistant")
+            .path("/api/init")
             .header("cookie", "kagi_session=test-session");
-        then.status(200).body(assistant_list_html());
+        then.status(200)
+            .json_body(assistant_init_json(json!([custom_assistant_json(
+                "profile-once",
+                "Once",
+                "gpt-5-mini"
+            )])));
     });
     let tempdir = TempDir::new().expect("tempdir");
     let env = session_env(&server);
@@ -2310,41 +2417,30 @@ fn completion_install_detects_fish_and_writes_completion_file() {
 fn assistant_once_creates_prompts_and_deletes_temporary_profile() {
     let server = MockServer::start();
     mock_current_assistant_prompt(&server, "Hi", None, "ok", None);
-    let _new_form = server.mock(|when, then| {
-        when.method(GET)
-            .path("/settings/custom_assistant")
-            .header("cookie", "kagi_session=test-session");
-        then.status(200)
-            .body(assistant_form_html("profile-once", "Once"));
-    });
     let _create = server.mock(|when, then| {
         when.method(POST)
-            .path("/settings/ast/profiles/update")
+            .path("/api/assistants")
             .header("cookie", "kagi_session=test-session")
-            .body_includes("base_model=gpt-5-mini");
-        then.status(303)
-            .header("location", "/settings/custom_assistant?id=profile-once");
+            .body_includes("\"llm_id\":\"gpt-5-mini\"");
+        then.status(200)
+            .json_body(custom_assistant_json("profile-once", "Once", "gpt-5-mini"));
     });
     let _list = server.mock(|when, then| {
         when.method(GET)
-            .path("/html/settings/assistant")
-            .header("cookie", "kagi_session=test-session");
-        then.status(200).body(assistant_list_html());
-    });
-    let _edit_form = server.mock(|when, then| {
-        when.method(GET)
-            .path("/settings/custom_assistant")
-            .query_param("id", "profile-once")
+            .path("/api/init")
             .header("cookie", "kagi_session=test-session");
         then.status(200)
-            .body(assistant_form_html("profile-once", "Once"));
+            .json_body(assistant_init_json(json!([custom_assistant_json(
+                "profile-once",
+                "Once",
+                "gpt-5-mini"
+            )])));
     });
     let _delete = server.mock(|when, then| {
-        when.method(POST)
-            .path("/settings/ast/profiles/delete")
-            .header("cookie", "kagi_session=test-session")
-            .body_includes("profile_id=profile-once");
-        then.status(200).body("");
+        when.method(DELETE)
+            .path("/api/assistants/profile-once")
+            .header("cookie", "kagi_session=test-session");
+        then.status(204);
     });
 
     let tempdir = TempDir::new().expect("tempdir");

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -2416,8 +2416,8 @@ fn completion_install_detects_fish_and_writes_completion_file() {
 #[test]
 fn assistant_once_creates_prompts_and_deletes_temporary_profile() {
     let server = MockServer::start();
-    mock_current_assistant_prompt(&server, "Hi", None, "ok", None);
-    let _create = server.mock(|when, then| {
+    let message = mock_current_assistant_prompt(&server, "Hi", None, "ok", Some("profile-once"));
+    let create = server.mock(|when, then| {
         when.method(POST)
             .path("/api/assistants")
             .header("cookie", "kagi_session=test-session")
@@ -2425,7 +2425,7 @@ fn assistant_once_creates_prompts_and_deletes_temporary_profile() {
         then.status(200)
             .json_body(custom_assistant_json("profile-once", "Once", "gpt-5-mini"));
     });
-    let _list = server.mock(|when, then| {
+    let list = server.mock(|when, then| {
         when.method(GET)
             .path("/api/init")
             .header("cookie", "kagi_session=test-session");
@@ -2436,7 +2436,7 @@ fn assistant_once_creates_prompts_and_deletes_temporary_profile() {
                 "gpt-5-mini"
             )])));
     });
-    let _delete = server.mock(|when, then| {
+    let delete = server.mock(|when, then| {
         when.method(DELETE)
             .path("/api/assistants/profile-once")
             .header("cookie", "kagi_session=test-session");
@@ -2454,6 +2454,10 @@ fn assistant_once_creates_prompts_and_deletes_temporary_profile() {
     assert_success(&output);
     let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
     assert_eq!(body["message"]["markdown"], "ok");
+    create.assert_calls(1);
+    list.assert_calls(2);
+    message.assert_calls(1);
+    delete.assert_calls(1);
 }
 
 #[test]


### PR DESCRIPTION
## summary

`kagi assistant custom create` was still using the removed HTML settings form, so the command failed with `assistant form missing name`.

this change moves custom assistant list, get, create, update, and delete to Kagi's current Assistant API. it also removes the obsolete HTML assistant parsers and adds regression coverage for the issue command, update flow, and temporary `assistant --once` cleanup.

fixes #161

## verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -q`
- [x] `make check`
- [x] read-only inspection of the current `assistant.kagi.com/api/init` response and current Assistant API surface
- [ ] human testing: pending. no human ran these checks in this turn.

## docs

- [x] README updated if user-facing behavior changed: existing command usage remains accurate
- [x] CHANGELOG updated for the user-facing fix

## auth / secrets

- [x] no tokens, cookies, or local config secrets were committed
- [x] live verification was read-only and no credentials are included

## ai assistance disclosure

```yaml
agent_name: "OpenAI Codex"
agent_version: "codex-cli 0.147.0"
model_used: "GPT-5"
human_testing: "none performed; automated checks were run by OpenAI Codex. draft PR only until a human tests the command."
contribution_summary: "migrated custom assistant CRUD from the removed HTML settings form to Kagi's current Assistant API and added regression coverage."
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating, updating, deleting, and viewing custom Assistant profiles through the current API.
  * Custom Assistant options now include model, web access, lens, and instructions settings.
  * Assistant initialization now displays built-in and custom assistants with model and profile details.

* **Bug Fixes**
  * Fixed `kagi assistant custom` failing when processing the removed settings form.

* **Tests**
  * Added coverage for custom Assistant creation, updates, and command-line option parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrates custom-assistant management from obsolete HTML settings forms to Kagi's current Assistant API.
- Uses `/api/init` to retrieve built-in and custom assistant profiles.
- Uses JSON POST, PATCH, and DELETE requests for custom-assistant lifecycle operations.
- Removes obsolete assistant HTML parsers and updates CLI and lifecycle regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/api.rs | Replaces HTML-based custom-assistant CRUD with current Assistant API models, payloads, resolution, and HTTP helpers. |
| src/parser.rs | Removes the obsolete assistant profile HTML parsers and their unit tests. |
| src/cli.rs | Adds parser coverage for custom-assistant creation options. |
| tests/integration-cli.rs | Updates Assistant API fixtures and covers create, update, profile resolution, and temporary-profile cleanup. |
| CHANGELOG.md | Documents the custom-assistant creation fix. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI
    participant Init as /api/init
    participant Assistants as /api/assistants
    CLI->>Init: Fetch models and assistant profiles
    Init-->>CLI: Built-in and custom assistants
    CLI->>Assistants: POST or PATCH JSON profile
    Assistants-->>CLI: Custom assistant details
    opt Temporary --once profile
        CLI->>Assistants: "DELETE /api/assistants/{uuid}"
        Assistants-->>CLI: 204 No Content
    end
```

<sub>Reviews (3): Last reviewed commit: ["fix: preserve assistant profile output d..."](https://github.com/microck/kagi-cli/commit/184ccc9d41f7f5204e0a8dc6b357f380feee55ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54147904)</sub>

<!-- /greptile_comment -->