### PR TITLE
fix: update subscriber summarizer request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,12 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+## [0.17.1]
+
 ### Fixed
 
 - Subscriber summarization now redacts session tokens from response-body error details and surfaces final stream errors even when an earlier message frame was received.
 - `kagi summarize --subscriber` now uses Kagi's current Assistant API endpoint and stream format.
-
-## [0.17.1]
-
-### Fixed
 
 - `kagi assistant custom` now uses Kagi's current Assistant API, so custom assistant creation no longer fails while parsing the removed settings form.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- Subscriber summarization now redacts session tokens from response-body error details and surfaces final stream errors even when an earlier message frame was received.
+- `kagi summarize --subscriber` now uses Kagi's current Assistant API endpoint and stream format.
+
 ## [0.17.1]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -500,7 +500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1211,7 +1211,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1601,7 +1601,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1859,7 +1859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1971,7 +1971,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/api.rs
+++ b/src/api.rs
@@ -2366,6 +2366,8 @@ fn looks_like_html_document(body: &str) -> bool {
 fn parse_subscriber_summarize_stream(body: &str) -> Result<SubscriberSummarizeResponse, KagiError> {
     let mut meta = SubscriberSummarizeMeta::default();
     let mut last_message: Option<SubscriberSummaryStreamMessage> = None;
+    let mut final_output: Option<String> = None;
+    let mut final_error: Option<String> = None;
 
     for frame in body.split("\0\n").filter(|frame| !frame.trim().is_empty()) {
         let Some((tag, payload)) = frame.split_once(':') else {
@@ -2392,17 +2394,54 @@ fn parse_subscriber_summarize_stream(body: &str) -> Result<SubscriberSummarizeRe
                     })?;
                 last_message = Some(message);
             }
+            "final" => {
+                let message: SubscriberSummaryAssistantFrame = serde_json::from_str(payload)
+                    .map_err(|error| {
+                        KagiError::Parse(format!(
+                            "failed to parse subscriber summarizer final frame: {error}"
+                        ))
+                    })?;
+                if message.error {
+                    let detail = message.output_text.trim();
+                    final_error = Some(if detail.is_empty() {
+                        "Kagi subscriber summarizer returned an error state".to_string()
+                    } else {
+                        format!("Kagi subscriber summarizer failed: {detail}")
+                    });
+                } else if !message.output_text.trim().is_empty() {
+                    final_output = Some(message.output_text);
+                }
+            }
             _ => {
                 debug!(tag, "ignoring unknown subscriber summarizer stream frame");
             }
         }
     }
 
-    let message = last_message.ok_or_else(|| {
-        KagiError::Parse(
-            "subscriber summarizer response did not include a new_message.json frame".to_string(),
-        )
-    })?;
+    let Some(message) = last_message else {
+        if let Some(detail) = final_error {
+            return Err(KagiError::Network(detail));
+        }
+        let output = final_output.ok_or_else(|| {
+            KagiError::Parse(
+                "subscriber summarizer response did not include a final summary frame".to_string(),
+            )
+        })?;
+        return Ok(SubscriberSummarizeResponse {
+            meta,
+            data: SubscriberSummarization {
+                id: String::new(),
+                thread_id: String::new(),
+                created_at: String::new(),
+                state: "done".to_string(),
+                prompt: String::new(),
+                markdown: output.clone(),
+                output,
+                metadata_html: String::new(),
+                documents: Vec::new(),
+            },
+        });
+    };
 
     if message.state == "error" {
         let detail = if message.reply.trim().is_empty() {
@@ -4707,6 +4746,14 @@ struct SubscriberSummaryStreamMessage {
     documents: Vec<Value>,
 }
 
+#[derive(Debug, Deserialize)]
+struct SubscriberSummaryAssistantFrame {
+    #[serde(default)]
+    error: bool,
+    #[serde(default)]
+    output_text: String,
+}
+
 #[cfg(test)]
 #[derive(Debug, Deserialize)]
 struct AssistantHello {
@@ -6044,6 +6091,17 @@ mod tests {
         assert_eq!(parsed.data.thread_id, "thread-1");
         assert_eq!(parsed.data.output, "summary output");
         assert_eq!(parsed.data.documents.len(), 1);
+    }
+
+    #[test]
+    fn parses_subscriber_summarize_final_stream() {
+        let raw = "update:{\"type\":\"update\",\"output_text\":\"\",\"output_data\":{\"status\":\"done\",\"title\":\"Example Domain\"},\"tokens\":0}\0\nfinal:{\"type\":\"final\",\"output_text\":\"summary output\",\"output_data\":null,\"tokens\":0,\"error\":false}\0\n";
+
+        let parsed = parse_subscriber_summarize_stream(raw).expect("stream parses");
+        assert_eq!(parsed.data.state, "done");
+        assert_eq!(parsed.data.output, "summary output");
+        assert_eq!(parsed.data.markdown, "summary output");
+        assert!(parsed.data.documents.is_empty());
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -269,21 +269,21 @@ pub async fn execute_subscriber_summarize(
             let body = http::read_error_body(response, "subscriber summarizer").await;
             Err(KagiError::Auth(format!(
                 "invalid or expired Kagi session token for subscriber summarizer: HTTP {status}{}",
-                format_client_error_suffix(&body)
+                format_client_error_suffix_redacting(&body, &[token])
             )))
         }
         status if status.is_server_error() => {
             let body = http::read_error_body(response, "subscriber summarizer").await;
             Err(KagiError::Network(format!(
                 "Kagi subscriber summarizer server error: HTTP {status}{}",
-                format_client_error_suffix(&body)
+                format_client_error_suffix_redacting(&body, &[token])
             )))
         }
         status => {
             let body = http::read_error_body(response, "subscriber summarizer").await;
             Err(KagiError::Network(format!(
                 "unexpected Kagi subscriber summarizer response status: HTTP {status}{}",
-                format_client_error_suffix(&body)
+                format_client_error_suffix_redacting(&body, &[token])
             )))
         }
     }
@@ -2418,10 +2418,11 @@ fn parse_subscriber_summarize_stream(body: &str) -> Result<SubscriberSummarizeRe
         }
     }
 
+    if let Some(detail) = final_error {
+        return Err(KagiError::Network(detail));
+    }
+
     let Some(message) = last_message else {
-        if let Some(detail) = final_error {
-            return Err(KagiError::Network(detail));
-        }
         let output = final_output.ok_or_else(|| {
             KagiError::Parse(
                 "subscriber summarizer response did not include a final summary frame".to_string(),
@@ -4299,6 +4300,18 @@ fn parse_content_disposition_filename(header_value: &str) -> Option<String> {
 }
 
 fn format_client_error_suffix(body: &str) -> String {
+    format_client_error_suffix_redacting(body, &[])
+}
+
+fn format_client_error_suffix_redacting(body: &str, secrets: &[&str]) -> String {
+    let sanitized = secrets.iter().fold(body.to_string(), |body, secret| {
+        if secret.is_empty() {
+            body
+        } else {
+            body.replace(secret, "[REDACTED]")
+        }
+    });
+    let body = sanitized.as_str();
     let trimmed = body.trim();
     if trimmed.is_empty() {
         return String::new();
@@ -5796,16 +5809,16 @@ mod tests {
         build_translate_word_insights_payload, capture_optional_translate_section,
         effective_translate_source_language, execute_news_filter_presets, extract_set_cookie_value,
         fake_header_map, finalize_translate_text_response, format_client_error_suffix,
-        normalize_ask_page_question, normalize_ask_page_url, normalize_assistant_query,
-        normalize_assistant_thread_id, normalize_assistant_thread_ref, normalize_aux_quality,
-        normalize_custom_bang_trigger, normalize_lens_name, normalize_redirect_rule,
-        normalize_subscriber_summary_input, normalize_subscriber_summary_length,
-        normalize_subscriber_summary_type, parse_assistant_thread_cursor,
-        parse_assistant_thread_delete_stream, parse_assistant_thread_list_stream,
-        parse_assistant_thread_open_stream, parse_content_disposition_filename,
-        parse_subscriber_summarize_stream, parse_translate_detect_value,
-        resolve_custom_assistant_ref, resolve_custom_bang_ref, resolve_lens_ref,
-        resolve_news_category, resolve_redirect_ref, resolve_translate_bootstrap,
+        format_client_error_suffix_redacting, normalize_ask_page_question, normalize_ask_page_url,
+        normalize_assistant_query, normalize_assistant_thread_id, normalize_assistant_thread_ref,
+        normalize_aux_quality, normalize_custom_bang_trigger, normalize_lens_name,
+        normalize_redirect_rule, normalize_subscriber_summary_input,
+        normalize_subscriber_summary_length, normalize_subscriber_summary_type,
+        parse_assistant_thread_cursor, parse_assistant_thread_delete_stream,
+        parse_assistant_thread_list_stream, parse_assistant_thread_open_stream,
+        parse_content_disposition_filename, parse_subscriber_summarize_stream,
+        parse_translate_detect_value, resolve_custom_assistant_ref, resolve_custom_bang_ref,
+        resolve_lens_ref, resolve_news_category, resolve_redirect_ref, resolve_translate_bootstrap,
         should_retry_lens_mutation_lookup, should_retry_translate_bootstrap,
         take_next_assistant_sse_frame, text_contains_news_filter_keyword,
         translate_subscription_error_message, validate_translate_request,
@@ -5984,6 +5997,26 @@ mod tests {
 
         assert_eq!(suffix.len(), 505);
         assert!(suffix.ends_with("..."));
+    }
+
+    #[test]
+    fn redacts_session_tokens_from_error_body_suffixes() {
+        let suffix = format_client_error_suffix_redacting(
+            r#"{"error":"kagi_session=session-secret"}"#,
+            &["session-secret"],
+        );
+
+        assert_eq!(suffix, r#"; {"error":"kagi_session=[REDACTED]"}"#);
+        assert!(!suffix.contains("session-secret"));
+    }
+
+    #[test]
+    fn final_subscriber_error_wins_over_an_earlier_message_frame() {
+        let raw = "new_message.json:{\"id\":\"msg-1\",\"thread_id\":\"thread-1\",\"created_at\":\"2026-03-16T05:17:57Z\",\"state\":\"done\",\"prompt\":\"hello\",\"reply\":\"stale output\",\"md\":\"stale output\",\"metadata\":\"\",\"documents\":[]}\0\nfinal:{\"type\":\"final\",\"output_text\":\"request failed\",\"error\":true}\0\n";
+
+        let error = parse_subscriber_summarize_stream(raw)
+            .expect_err("final error should not be hidden by an earlier message");
+        assert!(error.to_string().contains("request failed"));
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -207,7 +207,6 @@ pub async fn execute_extract(url: &str, token: &str) -> Result<String, KagiError
 ///
 /// # Arguments
 /// * `request` - The subscriber summarize request.
-/// * `list_id` - Optional thread or tag id used to continue listing.
 /// * `token` - The Kagi session token.
 ///
 /// # Returns
@@ -235,8 +234,8 @@ pub async fn execute_subscriber_summarize(
 
     let client = build_client()?;
     let response = client
-        .get(http::kagi_url(KAGI_SUBSCRIBER_SUMMARIZE_PATH))
-        .query(&[
+        .post(http::kagi_assistant_api_url(KAGI_SUBSCRIBER_SUMMARIZE_PATH))
+        .form(&[
             (field_name, source_value.as_str()),
             ("stream", "1"),
             ("target_language", target_language),

--- a/src/api.rs
+++ b/src/api.rs
@@ -232,7 +232,7 @@ pub async fn execute_subscriber_summarize(
     let summary_length = normalize_subscriber_summary_length(request.length.as_deref())?;
     let target_language = request.target_language.as_deref().map_or("", str::trim);
 
-    let client = build_client()?;
+    let client = http::client_assistant_stream()?;
     let response = client
         .post(http::kagi_assistant_api_url(KAGI_SUBSCRIBER_SUMMARIZE_PATH))
         .form(&[
@@ -263,7 +263,7 @@ pub async fn execute_subscriber_summarize(
                 ));
             }
 
-            parse_subscriber_summarize_stream(&body)
+            parse_subscriber_summarize_stream(&body, &[token])
         }
         status @ (StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) => {
             let body = http::read_error_body(response, "subscriber summarizer").await;
@@ -2363,7 +2363,10 @@ fn looks_like_html_document(body: &str) -> bool {
     body.contains("<!DOCTYPE html") || body.contains("<html")
 }
 
-fn parse_subscriber_summarize_stream(body: &str) -> Result<SubscriberSummarizeResponse, KagiError> {
+fn parse_subscriber_summarize_stream(
+    body: &str,
+    secrets: &[&str],
+) -> Result<SubscriberSummarizeResponse, KagiError> {
     let mut meta = SubscriberSummarizeMeta::default();
     let mut last_message: Option<SubscriberSummaryStreamMessage> = None;
     let mut final_output: Option<String> = None;
@@ -2402,7 +2405,7 @@ fn parse_subscriber_summarize_stream(body: &str) -> Result<SubscriberSummarizeRe
                         ))
                     })?;
                 if message.error {
-                    let detail = message.output_text.trim();
+                    let detail = redact_secrets(message.output_text.trim(), secrets);
                     final_error = Some(if detail.is_empty() {
                         "Kagi subscriber summarizer returned an error state".to_string()
                     } else {
@@ -2445,16 +2448,17 @@ fn parse_subscriber_summarize_stream(body: &str) -> Result<SubscriberSummarizeRe
     };
 
     if message.state == "error" {
-        let detail = if message.reply.trim().is_empty() {
+        let detail = redact_secrets(message.reply.trim(), secrets);
+        let detail = if detail.is_empty() {
             "Kagi subscriber summarizer returned an error state".to_string()
         } else {
-            format!(
-                "Kagi subscriber summarizer failed: {}",
-                message.reply.trim()
-            )
+            format!("Kagi subscriber summarizer failed: {detail}")
         };
         return Err(KagiError::Network(detail));
     }
+
+    let output = final_output.clone().unwrap_or(message.reply);
+    let markdown = final_output.unwrap_or(message.md);
 
     Ok(SubscriberSummarizeResponse {
         meta,
@@ -2464,8 +2468,8 @@ fn parse_subscriber_summarize_stream(body: &str) -> Result<SubscriberSummarizeRe
             created_at: message.created_at,
             state: message.state,
             prompt: message.prompt,
-            output: message.reply,
-            markdown: message.md,
+            output,
+            markdown,
             metadata_html: message.metadata,
             documents: message.documents,
         },
@@ -4299,18 +4303,22 @@ fn parse_content_disposition_filename(header_value: &str) -> Option<String> {
     None
 }
 
-fn format_client_error_suffix(body: &str) -> String {
-    format_client_error_suffix_redacting(body, &[])
-}
-
-fn format_client_error_suffix_redacting(body: &str, secrets: &[&str]) -> String {
-    let sanitized = secrets.iter().fold(body.to_string(), |body, secret| {
+fn redact_secrets(body: &str, secrets: &[&str]) -> String {
+    secrets.iter().fold(body.to_string(), |body, secret| {
         if secret.is_empty() {
             body
         } else {
             body.replace(secret, "[REDACTED]")
         }
-    });
+    })
+}
+
+fn format_client_error_suffix(body: &str) -> String {
+    format_client_error_suffix_redacting(body, &[])
+}
+
+fn format_client_error_suffix_redacting(body: &str, secrets: &[&str]) -> String {
+    let sanitized = redact_secrets(body, secrets);
     let body = sanitized.as_str();
     let trimmed = body.trim();
     if trimmed.is_empty() {
@@ -6012,11 +6020,22 @@ mod tests {
 
     #[test]
     fn final_subscriber_error_wins_over_an_earlier_message_frame() {
-        let raw = "new_message.json:{\"id\":\"msg-1\",\"thread_id\":\"thread-1\",\"created_at\":\"2026-03-16T05:17:57Z\",\"state\":\"done\",\"prompt\":\"hello\",\"reply\":\"stale output\",\"md\":\"stale output\",\"metadata\":\"\",\"documents\":[]}\0\nfinal:{\"type\":\"final\",\"output_text\":\"request failed\",\"error\":true}\0\n";
+        let raw = "new_message.json:{\"id\":\"msg-1\",\"thread_id\":\"thread-1\",\"created_at\":\"2026-03-16T05:17:57Z\",\"state\":\"done\",\"prompt\":\"hello\",\"reply\":\"stale output\",\"md\":\"stale output\",\"metadata\":\"\",\"documents\":[]}\0\nfinal:{\"type\":\"final\",\"output_text\":\"request failed session-secret\",\"error\":true}\0\n";
 
-        let error = parse_subscriber_summarize_stream(raw)
+        let error = parse_subscriber_summarize_stream(raw, &["session-secret"])
             .expect_err("final error should not be hidden by an earlier message");
-        assert!(error.to_string().contains("request failed"));
+        let message = error.to_string();
+        assert!(message.contains("request failed"));
+        assert!(!message.contains("session-secret"));
+    }
+
+    #[test]
+    fn successful_final_output_replaces_stale_earlier_message() {
+        let raw = "new_message.json:{\"id\":\"msg-1\",\"thread_id\":\"thread-1\",\"created_at\":\"2026-03-16T05:17:57Z\",\"state\":\"done\",\"prompt\":\"hello\",\"reply\":\"stale output\",\"md\":\"stale markdown\",\"metadata\":\"\",\"documents\":[]}\0\nfinal:{\"type\":\"final\",\"output_text\":\"terminal output\",\"error\":false}\0\n";
+
+        let parsed = parse_subscriber_summarize_stream(raw, &[]).expect("stream parses");
+        assert_eq!(parsed.data.output, "terminal output");
+        assert_eq!(parsed.data.markdown, "terminal output");
     }
 
     #[test]
@@ -6115,7 +6134,7 @@ mod tests {
     fn parses_subscriber_summarize_stream() {
         let raw = "hi:{\"v\":\"202603091651.stage.c128588\",\"trace\":\"abc123\"}\0\nnew_message.json:{\"id\":\"msg-1\",\"thread_id\":\"thread-1\",\"created_at\":\"2026-03-16T05:17:57Z\",\"state\":\"done\",\"prompt\":\"hello\",\"reply\":\"summary output\",\"md\":\"summary output\",\"metadata\":\"<li>meta</li>\",\"documents\":[{\"url\":\"https://example.com\"}]}\0\n";
 
-        let parsed = parse_subscriber_summarize_stream(raw).expect("stream parses");
+        let parsed = parse_subscriber_summarize_stream(raw, &[]).expect("stream parses");
         assert_eq!(
             parsed.meta.version.as_deref(),
             Some("202603091651.stage.c128588")
@@ -6130,7 +6149,7 @@ mod tests {
     fn parses_subscriber_summarize_final_stream() {
         let raw = "update:{\"type\":\"update\",\"output_text\":\"\",\"output_data\":{\"status\":\"done\",\"title\":\"Example Domain\"},\"tokens\":0}\0\nfinal:{\"type\":\"final\",\"output_text\":\"summary output\",\"output_data\":null,\"tokens\":0,\"error\":false}\0\n";
 
-        let parsed = parse_subscriber_summarize_stream(raw).expect("stream parses");
+        let parsed = parse_subscriber_summarize_stream(raw, &[]).expect("stream parses");
         assert_eq!(parsed.data.state, "done");
         assert_eq!(parsed.data.output, "summary output");
         assert_eq!(parsed.data.markdown, "summary output");
@@ -6141,7 +6160,8 @@ mod tests {
     fn rejects_error_state_in_subscriber_summarize_stream() {
         let raw = "new_message.json:{\"id\":\"msg-1\",\"thread_id\":\"thread-1\",\"created_at\":\"2026-03-16T05:17:57Z\",\"state\":\"error\",\"prompt\":\"hello\",\"reply\":\"We are sorry, we are not able to extract the source.\",\"md\":\"\",\"metadata\":\"\",\"documents\":[]}\0\n";
 
-        let error = parse_subscriber_summarize_stream(raw).expect_err("error state should fail");
+        let error =
+            parse_subscriber_summarize_stream(raw, &[]).expect_err("error state should fail");
         assert!(
             error
                 .to_string()

--- a/src/http.rs
+++ b/src/http.rs
@@ -13,11 +13,13 @@ const USER_AGENT: &str = concat!(
 );
 const DEFAULT_KAGI_BASE_URL: &str = "https://kagi.com";
 const DEFAULT_KAGI_ASSISTANT_BASE_URL: &str = "https://assistant.kagi.com";
+const DEFAULT_KAGI_ASSISTANT_API_BASE_URL: &str = "https://assistant-api.kagi.com";
 const DEFAULT_KAGI_NEWS_BASE_URL: &str = "https://news.kagi.com";
 const DEFAULT_KAGI_TRANSLATE_BASE_URL: &str = "https://translate.kagi.com";
 
 pub const KAGI_BASE_URL_ENV: &str = "KAGI_BASE_URL";
 pub const KAGI_ASSISTANT_BASE_URL_ENV: &str = "KAGI_ASSISTANT_BASE_URL";
+pub const KAGI_ASSISTANT_API_BASE_URL_ENV: &str = "KAGI_ASSISTANT_API_BASE_URL";
 pub const KAGI_NEWS_BASE_URL_ENV: &str = "KAGI_NEWS_BASE_URL";
 pub const KAGI_TRANSLATE_BASE_URL_ENV: &str = "KAGI_TRANSLATE_BASE_URL";
 
@@ -161,6 +163,24 @@ pub fn kagi_assistant_url(path: &str) -> String {
     )
 }
 
+/// Builds a full Kagi Assistant API URL from a path, using the `KAGI_ASSISTANT_API_BASE_URL`
+/// env override or the default current Assistant API origin.
+///
+/// # Arguments
+/// * `path` - Assistant API path (e.g. `"/mother/summary_labs"`). Absolute URLs are returned unchanged.
+///
+/// # Returns
+/// The complete URL string.
+pub fn kagi_assistant_api_url(path: &str) -> String {
+    build_url(
+        &base_url_from_env(
+            KAGI_ASSISTANT_API_BASE_URL_ENV,
+            DEFAULT_KAGI_ASSISTANT_API_BASE_URL,
+        ),
+        path,
+    )
+}
+
 /// Builds a full Kagi News API URL from a path, using the `KAGI_NEWS_BASE_URL` env override or the default.
 ///
 /// # Arguments
@@ -231,9 +251,9 @@ fn build_url(base: &str, path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        KAGI_ASSISTANT_BASE_URL_ENV, KAGI_BASE_URL_ENV, KAGI_NEWS_BASE_URL_ENV,
-        KAGI_TRANSLATE_BASE_URL_ENV, kagi_assistant_url, kagi_news_url, kagi_translate_url,
-        kagi_url,
+        KAGI_ASSISTANT_API_BASE_URL_ENV, KAGI_ASSISTANT_BASE_URL_ENV, KAGI_BASE_URL_ENV,
+        KAGI_NEWS_BASE_URL_ENV, KAGI_TRANSLATE_BASE_URL_ENV, kagi_assistant_api_url,
+        kagi_assistant_url, kagi_news_url, kagi_translate_url, kagi_url,
     };
     use crate::test_support::lock_env;
 
@@ -251,6 +271,7 @@ mod tests {
 
         remove_env_var(KAGI_BASE_URL_ENV);
         remove_env_var(KAGI_ASSISTANT_BASE_URL_ENV);
+        remove_env_var(KAGI_ASSISTANT_API_BASE_URL_ENV);
         remove_env_var(KAGI_NEWS_BASE_URL_ENV);
         remove_env_var(KAGI_TRANSLATE_BASE_URL_ENV);
 
@@ -258,6 +279,10 @@ mod tests {
         assert_eq!(
             kagi_assistant_url("/api/conversations"),
             "https://assistant.kagi.com/api/conversations"
+        );
+        assert_eq!(
+            kagi_assistant_api_url("/mother/summary_labs"),
+            "https://assistant-api.kagi.com/mother/summary_labs"
         );
         assert_eq!(
             kagi_news_url("/api/batches/latest"),
@@ -275,6 +300,7 @@ mod tests {
 
         set_env_var(KAGI_BASE_URL_ENV, "http://127.0.0.1:9000/");
         set_env_var(KAGI_ASSISTANT_BASE_URL_ENV, "http://127.0.0.1:9001/");
+        set_env_var(KAGI_ASSISTANT_API_BASE_URL_ENV, "http://127.0.0.1:9002/");
         set_env_var(KAGI_NEWS_BASE_URL_ENV, "http://127.0.0.1:9002/");
         set_env_var(KAGI_TRANSLATE_BASE_URL_ENV, "http://127.0.0.1:9003/");
 
@@ -287,6 +313,10 @@ mod tests {
             "http://127.0.0.1:9001/api/conversations"
         );
         assert_eq!(
+            kagi_assistant_api_url("/mother/summary_labs"),
+            "http://127.0.0.1:9002/mother/summary_labs"
+        );
+        assert_eq!(
             kagi_news_url("/api/batches/latest"),
             "http://127.0.0.1:9002/api/batches/latest"
         );
@@ -297,6 +327,7 @@ mod tests {
 
         remove_env_var(KAGI_BASE_URL_ENV);
         remove_env_var(KAGI_ASSISTANT_BASE_URL_ENV);
+        remove_env_var(KAGI_ASSISTANT_API_BASE_URL_ENV);
         remove_env_var(KAGI_NEWS_BASE_URL_ENV);
         remove_env_var(KAGI_TRANSLATE_BASE_URL_ENV);
     }

--- a/src/mcp_install.rs
+++ b/src/mcp_install.rs
@@ -517,16 +517,12 @@ fn current_kagi_exe() -> Result<PathBuf, KagiError> {
 fn vscode_user_mcp_config_path() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
-        if let Some(config_home) = explicit_xdg_config_home() {
-            config_home.join("Code").join("User").join("mcp.json")
-        } else {
-            home_dir()
-                .join("Library")
-                .join("Application Support")
-                .join("Code")
-                .join("User")
-                .join("mcp.json")
-        }
+        home_dir()
+            .join("Library")
+            .join("Application Support")
+            .join("Code")
+            .join("User")
+            .join("mcp.json")
     }
 
     #[cfg(target_os = "windows")]
@@ -552,17 +548,11 @@ fn path_string(path: &Path) -> String {
 fn claude_desktop_config_path() -> Result<PathBuf, KagiError> {
     #[cfg(target_os = "macos")]
     {
-        if let Some(config_home) = explicit_xdg_config_home() {
-            Ok(config_home
-                .join("Claude")
-                .join("claude_desktop_config.json"))
-        } else {
-            Ok(home_dir()
-                .join("Library")
-                .join("Application Support")
-                .join("Claude")
-                .join("claude_desktop_config.json"))
-        }
+        Ok(home_dir()
+            .join("Library")
+            .join("Application Support")
+            .join("Claude")
+            .join("claude_desktop_config.json"))
     }
 
     #[cfg(target_os = "windows")]
@@ -601,8 +591,7 @@ fn roo_code_config_candidates() -> Result<Vec<PathBuf>, KagiError> {
 
     #[cfg(target_os = "macos")]
     {
-        let root = explicit_xdg_config_home()
-            .unwrap_or_else(|| home_dir().join("Library").join("Application Support"));
+        let root = home_dir().join("Library").join("Application Support");
         Ok(["Code", "Cursor", "Windsurf", "VSCodium"]
             .iter()
             .map(|name| root.join(name).join(&relative))
@@ -690,12 +679,6 @@ fn xdg_config_home() -> PathBuf {
         .map(PathBuf::from)
         .filter(|value| !value.as_os_str().is_empty())
         .unwrap_or_else(|| home_dir().join(".config"))
-}
-
-fn explicit_xdg_config_home() -> Option<PathBuf> {
-    env::var_os("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .filter(|value| !value.as_os_str().is_empty())
 }
 
 fn home_dir() -> PathBuf {

--- a/src/mcp_install.rs
+++ b/src/mcp_install.rs
@@ -517,12 +517,16 @@ fn current_kagi_exe() -> Result<PathBuf, KagiError> {
 fn vscode_user_mcp_config_path() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
-        return home_dir()
-            .join("Library")
-            .join("Application Support")
-            .join("Code")
-            .join("User")
-            .join("mcp.json");
+        if let Some(config_home) = explicit_xdg_config_home() {
+            config_home.join("Code").join("User").join("mcp.json")
+        } else {
+            home_dir()
+                .join("Library")
+                .join("Application Support")
+                .join("Code")
+                .join("User")
+                .join("mcp.json")
+        }
     }
 
     #[cfg(target_os = "windows")]
@@ -548,11 +552,17 @@ fn path_string(path: &Path) -> String {
 fn claude_desktop_config_path() -> Result<PathBuf, KagiError> {
     #[cfg(target_os = "macos")]
     {
-        return Ok(home_dir()
-            .join("Library")
-            .join("Application Support")
-            .join("Claude")
-            .join("claude_desktop_config.json"));
+        if let Some(config_home) = explicit_xdg_config_home() {
+            Ok(config_home
+                .join("Claude")
+                .join("claude_desktop_config.json"))
+        } else {
+            Ok(home_dir()
+                .join("Library")
+                .join("Application Support")
+                .join("Claude")
+                .join("claude_desktop_config.json"))
+        }
     }
 
     #[cfg(target_os = "windows")]
@@ -591,11 +601,12 @@ fn roo_code_config_candidates() -> Result<Vec<PathBuf>, KagiError> {
 
     #[cfg(target_os = "macos")]
     {
-        let root = home_dir().join("Library").join("Application Support");
-        return Ok(["Code", "Cursor", "Windsurf", "VSCodium"]
+        let root = explicit_xdg_config_home()
+            .unwrap_or_else(|| home_dir().join("Library").join("Application Support"));
+        Ok(["Code", "Cursor", "Windsurf", "VSCodium"]
             .iter()
             .map(|name| root.join(name).join(&relative))
-            .collect());
+            .collect())
     }
 
     #[cfg(target_os = "windows")]
@@ -679,6 +690,12 @@ fn xdg_config_home() -> PathBuf {
         .map(PathBuf::from)
         .filter(|value| !value.as_os_str().is_empty())
         .unwrap_or_else(|| home_dir().join(".config"))
+}
+
+fn explicit_xdg_config_home() -> Option<PathBuf> {
+    env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|value| !value.as_os_str().is_empty())
 }
 
 fn home_dir() -> PathBuf {

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -1642,6 +1642,45 @@ fn subscriber_summarize_posts_form_to_assistant_api() {
 }
 
 #[test]
+fn subscriber_summarize_redacts_session_token_from_error_output() {
+    let server = MockServer::start();
+    let summarize = server.mock(|when, then| {
+        when.method(POST).path("/mother/summary_labs");
+        then.status(500)
+            .header("content-type", "application/json")
+            .body(r#"{"error":"upstream echoed kagi_session=test-session"}"#);
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = session_env(&server);
+    let output = run_kagi(
+        &[
+            "summarize",
+            "--subscriber",
+            "--url",
+            "https://example.com/article",
+        ],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert!(
+        !output.status.success(),
+        "server error should fail the command"
+    );
+    summarize.assert_calls(1);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("HTTP 500"),
+        "expected HTTP status in error: {stderr}"
+    );
+    assert!(
+        !stderr.contains("test-session"),
+        "session token must not appear in error output: {stderr}"
+    );
+}
+
+#[test]
 fn extract_command_prints_markdown_from_mock_api() {
     let server = MockServer::start();
     let _extract = server.mock(|when, then| {

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
@@ -106,6 +106,21 @@ fn write_config(cwd: &Path, contents: &str) {
     fs::create_dir_all(path.parent().expect("config path has a parent"))
         .expect("config directory should create");
     fs::write(path, contents).expect("config should write");
+}
+
+fn vscode_user_dir(cwd: &Path) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        cwd.join("Library")
+            .join("Application Support")
+            .join("Code")
+            .join("User")
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        cwd.join(".config").join("Code").join("User")
+    }
 }
 
 fn assert_success(output: &Output) {
@@ -1406,15 +1421,8 @@ fn mcp_install_writes_vs_code_user_config_without_client_cli() {
     );
 
     assert_success(&output);
-    let raw = fs::read_to_string(
-        tempdir
-            .path()
-            .join(".config")
-            .join("Code")
-            .join("User")
-            .join("mcp.json"),
-    )
-    .expect("VS Code MCP config should be written");
+    let raw = fs::read_to_string(vscode_user_dir(tempdir.path()).join("mcp.json"))
+        .expect("VS Code MCP config should be written");
     let config: Value = serde_json::from_str(&raw).expect("VS Code MCP config should parse");
     assert_eq!(
         config["servers"]["kagi-mcp"],
@@ -1442,11 +1450,7 @@ fn mcp_install_writes_roo_code_extension_config() {
     );
 
     assert_success(&output);
-    let path = tempdir
-        .path()
-        .join(".config")
-        .join("Code")
-        .join("User")
+    let path = vscode_user_dir(tempdir.path())
         .join("globalStorage")
         .join("rooveterinaryinc.roo-cline")
         .join("settings")

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -23,6 +23,7 @@ fn run_kagi(args: &[&str], envs: &[(&str, &str)], cwd: &Path) -> Output {
         "KAGI_SESSION_TOKEN",
         "KAGI_BASE_URL",
         "KAGI_ASSISTANT_BASE_URL",
+        "KAGI_ASSISTANT_API_BASE_URL",
         "KAGI_NEWS_BASE_URL",
         "KAGI_TRANSLATE_BASE_URL",
         "KAGI_ERROR_FORMAT",
@@ -58,6 +59,7 @@ fn run_kagi_with_stdin(args: &[&str], stdin: &str, envs: &[(&str, &str)], cwd: &
         "KAGI_SESSION_TOKEN",
         "KAGI_BASE_URL",
         "KAGI_ASSISTANT_BASE_URL",
+        "KAGI_ASSISTANT_API_BASE_URL",
         "KAGI_NEWS_BASE_URL",
         "KAGI_TRANSLATE_BASE_URL",
         "KAGI_ERROR_FORMAT",
@@ -361,6 +363,7 @@ fn session_env(server: &MockServer) -> Vec<(&'static str, String)> {
         ("KAGI_SESSION_TOKEN", "test-session".to_string()),
         ("KAGI_BASE_URL", server.base_url()),
         ("KAGI_ASSISTANT_BASE_URL", server.base_url()),
+        ("KAGI_ASSISTANT_API_BASE_URL", server.base_url()),
     ]
 }
 
@@ -1591,6 +1594,47 @@ fn summarize_url_command_prints_structured_json() {
     assert_success(&output);
     let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
     assert_eq!(body["data"]["output"], "A concise summary.");
+}
+
+#[test]
+fn subscriber_summarize_posts_form_to_assistant_api() {
+    let server = MockServer::start();
+    let summarize = server.mock(|when, then| {
+        when.method(POST)
+            .path("/mother/summary_labs")
+            .header("cookie", "kagi_session=test-session")
+            .header("accept", "application/vnd.kagi.stream")
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body_includes("url=https%3A%2F%2Fexample.com%2Farticle")
+            .body_includes("stream=1")
+            .body_includes("summary_type=keypoints")
+            .body_includes("summary_length=digest");
+        then.status(200)
+            .header("content-type", "application/vnd.kagi.stream")
+            .body("hi:{\"v\":\"test\",\"trace\":\"trace-1\"}\0\nnew_message.json:{\"id\":\"msg-1\",\"thread_id\":\"thread-1\",\"created_at\":\"2026-03-16T05:17:57Z\",\"state\":\"done\",\"prompt\":\"hello\",\"reply\":\"summary output\",\"md\":\"summary output\",\"metadata\":\"\",\"documents\":[{\"url\":\"https://example.com/article\"}]}\0\n");
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = session_env(&server);
+    let output = run_kagi(
+        &[
+            "summarize",
+            "--subscriber",
+            "--url",
+            "https://example.com/article",
+            "--summary-type",
+            "keypoints",
+            "--length",
+            "digest",
+        ],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    summarize.assert_calls(1);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    assert_eq!(body["data"]["output"], "summary output");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- update `kagi summarize --subscriber` to call the current Assistant API summarizer endpoint with form-encoded `POST`
- add `KAGI_ASSISTANT_API_BASE_URL` for testing and local endpoint overrides
- add regression coverage for subscriber summarizer method, path, headers, form body, and parsed CLI output
- parse current subscriber summarizer `final` stream frames that carry the summary text in `output_text`
- keep macOS MCP installs on native Application Support paths while keeping integration tests isolated under the sandboxed temp home

fixes #164

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -q`
- [x] `git diff --check`
- [x] `cargo test --test integration-cli subscriber_summarize_posts_form_to_assistant_api`

## Docs

- [x] README updated if user-facing behavior changed: existing command usage remains accurate
- [ ] CHANGELOG updated for notable user-facing changes

## Auth / Secrets

- [x] No tokens, cookies, or local config secrets were committed
- [x] Any live verification steps are documented without exposing credentials




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriber summarization now uses the Assistant API and supports streaming responses.
  * Added configurable Assistant API endpoint support.

* **Bug Fixes**
  * Improved handling of streaming errors and final responses.
  * Session tokens are now hidden from summarization error details.
  * Corrected macOS configuration paths for MCP integrations.

* **Documentation**
  * Updated changelog categorization for these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates subscriber summarization to the current Assistant API and updates parsing for its terminal stream frames.
- Sends form-encoded subscriber requests to the configurable Assistant API endpoint.
- Handles final output and error frames while redacting session tokens from reported errors.
- Keeps macOS MCP configuration under native Application Support paths and expands regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/api.rs | Migrates subscriber summarization to form-encoded Assistant API requests and supports terminal output and error frames with secret redaction. |
| src/http.rs | Adds a configurable base URL builder for the Assistant API origin. |
| src/mcp_install.rs | Preserves native macOS Application Support paths for MCP client configuration. |
| tests/integration-cli.rs | Adds coverage for the subscriber request contract, parsed output, token redaction, and platform-specific MCP paths. |
| Cargo.lock | Refreshes transitive lockfile resolutions without introducing a demonstrated changed-code failure. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as kagi CLI
    participant API as Assistant API
    CLI->>API: POST /mother/summary_labs (form + session cookie)
    API-->>CLI: Kagi stream frames
    CLI->>CLI: Parse metadata/message/final frames
    alt final error
        CLI-->>CLI: Redact session token and return error
    else final output
        CLI-->>CLI: Return parsed summary JSON
    end
```

<sub>Reviews (7): Last reviewed commit: ["fix(summarize): harden subscriber stream..."](https://github.com/microck/kagi-cli/commit/c72d85c7551a85c3e63980c2e702766b387e6d91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55374716)</sub>

<!-- /greptile_comment -->