### PR TITLE
fix: match release changelog parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
-## [0.17.2] - 2026-08-21
+## [0.17.2]
 
 ### Fixed
 


### PR DESCRIPTION
The release workflow extracts notes only from an exact `## [X.Y.Z]` heading.

This changes the 0.17.2 heading to the format required by the workflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns the 0.17.2 changelog heading with the exact format expected by the release-note parser.
- Removes the release date suffix from the `0.17.2` heading.
- Leaves the release notes themselves unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The only change makes the changelog heading match the release workflow’s documented exact-match format, with no code, security, or release-note content changes.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Updates the 0.17.2 heading to the parser-compatible `## [X.Y.Z]` format without altering release content. |

<sub>Reviews (1): Last reviewed commit: ["fix: match release changelog parser"](https://github.com/microck/kagi-cli/commit/fc2d944b80c0ce2b0776969ec65b1a61dc07b4a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55496569)</sub>

<!-- /greptile_comment -->