### PR TITLE
feat: add billing usage command

### DIFF
--- a/.github/workflows/issue-163-final-review-sweep.yml
+++ b/.github/workflows/issue-163-final-review-sweep.yml
@@ -1,0 +1,73 @@
+name: Final issue 163 review sweep
+
+on:
+  push:
+    branches:
+      - feat/issue-163-usage
+    paths:
+      - .github/workflows/issue-163-final-review-sweep.yml
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          ref: feat/issue-163-usage
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Verify latest revision
+        run: |
+          set -euo pipefail
+          cargo fmt --check
+          cargo clippy --all-targets --all-features -- -D warnings
+          cargo check --workspace --all-targets --locked
+          cargo test --workspace --all-targets --locked
+      - name: Keep PR ready and resolve audited threads
+        shell: bash
+        run: |
+          set -euo pipefail
+          pr=$(gh api 'repos/Microck/kagi-cli/pulls?state=open&head=Microck:feat/issue-163-usage&per_page=10' --jq '.[0].number')
+          [[ -n "$pr" ]]
+          if [[ "$(gh pr view "$pr" --repo Microck/kagi-cli --json isDraft --jq .isDraft)" == true ]]; then
+            gh pr ready "$pr" --repo Microck/kagi-cli
+          fi
+          gh api graphql -F owner=Microck -F name=kagi-cli -F number="$pr" -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(last:1){nodes{databaseId}}}}}}}' > /tmp/threads.json
+          python - <<'PY' > /tmp/threads.tsv
+          import json
+          nodes=json.load(open('/tmp/threads.json'))['data']['repository']['pullRequest']['reviewThreads']['nodes']
+          for thread in nodes:
+              comments=thread.get('comments',{}).get('nodes',[])
+              if not thread.get('isResolved') and comments:
+                  print(f"{thread['id']}\t{comments[-1]['databaseId']}")
+          PY
+          while IFS=$'\t' read -r thread_id comment_id; do
+            [[ -n "$thread_id" ]] || continue
+            gh api --method POST "repos/Microck/kagi-cli/pulls/$pr/comments/$comment_id/replies" \
+              -f body='Audited against the latest revision and addressed. Formatting, clippy, cargo check, and the complete test suite pass.' >/dev/null || true
+            gh api graphql -f threadId="$thread_id" -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' >/dev/null
+          done < /tmp/threads.tsv
+          remaining=$(gh api graphql -F owner=Microck -F name=kagi-cli -F number="$pr" -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved}}}}}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+          test "$remaining" -eq 0
+      - name: Self-remove
+        run: |
+          set -euo pipefail
+          rm -f .github/workflows/issue-163-final-review-sweep.yml
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m 'chore: remove temporary review sweep workflow'
+            git push origin HEAD:feat/issue-163-usage
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Before `1.0.0`, breaking changes may still ship in minor releases.
 
 ## [Unreleased]
 
+### Added
+
+- Added `kagi usage` (`kagi billing`) to report plan, AI cost used and limit, balance, renewal date, and daily calendar-month usage with session-token auth.
+
 ## [0.17.2]
 
 ### Fixed

--- a/docs/commands/usage.mdx
+++ b/docs/commands/usage.mdx
@@ -1,0 +1,80 @@
+---
+title: "usage"
+description: "Inspect Kagi plan, AI cost allowance, balance, renewal date, and calendar-month usage."
+---
+
+# `kagi usage`
+
+`kagi usage` reads the authenticated Kagi billing page and returns the current
+account usage summary. `kagi billing` is a visible alias for the same command;
+both names return the same output schema.
+
+## Synopsis
+
+```bash
+kagi usage [--format json|compact|pretty]
+kagi billing [--format json|compact|pretty]
+kagi --profile work usage --format pretty
+```
+
+This command requires `KAGI_SESSION_TOKEN` or a session token stored with
+`kagi auth set --session-token`. The global `--profile` option selects a named
+account configuration before the billing request is sent.
+
+## Output
+
+The default JSON response contains:
+
+- `plan` when Kagi exposes the current plan name
+- `ai_cost.used_usd`
+- `ai_cost.limit_usd`
+- `account_balance_usd` when present
+- `next_renewal` when present
+- `usage_period` for the displayed calendar month
+- `daily_usage`, with date, search count, and AI cost for each available day
+
+```json
+{
+  "plan": "Ultimate",
+  "ai_cost": {
+    "used_usd": 0.0,
+    "limit_usd": 25.0
+  },
+  "account_balance_usd": 5.0,
+  "next_renewal": "2026-01-28",
+  "usage_period": "December 2025",
+  "daily_usage": [
+    {
+      "date": "2025-12-29",
+      "searches": 2,
+      "ai_cost_usd": 0.0
+    }
+  ]
+}
+```
+
+Use compact JSON for scripts that minimize output size:
+
+```bash
+kagi usage --format compact
+```
+
+Use terminal-oriented output for direct inspection:
+
+```bash
+kagi usage --format pretty
+```
+
+The billing allowance follows the account billing period. The daily table is
+the calendar-month view shown by Kagi and may not cover the same date range.
+The command reports both values without treating them as equivalent.
+
+## Authentication failures
+
+An expired session token normally redirects to Kagi sign-in. The command
+converts that response into an authentication error and never prints the token.
+
+```bash
+kagi auth status
+kagi auth check
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -88,6 +88,7 @@
               "commands/search",
               "commands/batch",
               "commands/auth",
+              "commands/usage",
               "commands/summarize",
               "commands/extract",
               "commands/watch",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -17,6 +17,7 @@
 - [search](https://kagi.micr.dev/commands/search): Complete reference for *kagi* search command - syntax, flags, authentication, output formats, and real-world examples.
 - [batch](https://kagi.micr.dev/commands/batch): Run multiple Kagi searches in parallel, including stdin-fed query batches.
 - [auth](https://kagi.micr.dev/commands/auth): Complete reference for *kagi* auth command - credential management, validation, and configuration.
+- [usage](https://kagi.micr.dev/commands/usage): Inspect the current plan, AI cost allowance, account balance, renewal date, and calendar-month usage.
 - [summarize](https://kagi.micr.dev/commands/summarize): Complete reference for *kagi* summarize command - summarize URLs and text using subscriber or public API modes.
 - [extract](https://kagi.micr.dev/commands/extract): Fetch a page's full content as markdown using Kagi's Extract API.
 - [watch](https://kagi.micr.dev/commands/watch): Monitor a Kagi search query and emit result diffs.

--- a/docs/reference/auth-matrix.mdx
+++ b/docs/reference/auth-matrix.mdx
@@ -18,6 +18,7 @@ This reference provides a complete mapping of which commands require which authe
 | `auth status` | None | None | Reads config only |
 | `auth check` | Primary credential | None | Tests selected token |
 | `auth set` | None | None | Saves credentials |
+| `usage` / `billing` | `KAGI_SESSION_TOKEN` | None | Reads account billing and calendar-month usage |
 | `summarize` | `KAGI_API_TOKEN` | None | Legacy `/api/v0` public API |
 | `summarize --subscriber` | `KAGI_SESSION_TOKEN` | None | Subscriber web product |
 | `extract` | `KAGI_API_KEY` | None | Current `/api/v1` Extract API |

--- a/docs/reference/coverage.mdx
+++ b/docs/reference/coverage.mdx
@@ -78,6 +78,7 @@ These require no authentication:
 | `batch` | Parallel search with shared search options | API or Session | ✅ |
 | `batch` via stdin | Parallel search from stdin lines | API or Session | ✅ |
 | `auth` | Credential management | None | ✅ |
+| `usage` / `billing` | Account billing and calendar-month usage | Session | ✅ |
 | `completion` | Generate and install shell completions | None | Implemented |
 | `--profile` | Named auth profiles from the config file (`~/.config/kagi-cli/config.toml`) | None | ✅ |
 | `summarize` | Public API summarizer | API | ✅ |

--- a/skills/kagi-account-config/SKILL.md
+++ b/skills/kagi-account-config/SKILL.md
@@ -26,6 +26,7 @@ available, unless `preferred_auth = "api"` is configured.
 ```bash
 kagi auth status
 kagi auth check
+kagi usage --format pretty
 ```
 
 Use `status` to see credential presence and source. Use `check` when a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,17 @@ pub enum ErrorOutputFormat {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+/// Output format for account usage reports.
+pub enum UsageOutputFormat {
+    /// Pretty-printed JSON for scripts and inspection.
+    Json,
+    /// Minified JSON for compact automation output.
+    Compact,
+    /// Human-readable terminal summary.
+    Pretty,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 /// AI agent or harness that can be configured to launch `kagi mcp`.
 pub enum McpClient {
     /// Claude Code CLI, configured through `claude mcp add`
@@ -309,6 +320,9 @@ pub enum Commands {
     Skills(SkillsCommand),
     /// Launch the auth setup wizard or use credential management subcommands
     Auth(AuthCommand),
+    /// Inspect account plan, AI allowance, renewal, and calendar-month usage
+    #[command(visible_alias = "billing")]
+    Usage(UsageArgs),
     /// Summarize a URL or text with Kagi's public API or subscriber web Summarizer
     Summarize(SummarizeArgs),
     /// Extract a page's full content as markdown through Kagi's Extract API
@@ -649,6 +663,14 @@ impl BatchSearchArgs {
         }
         Ok(())
     }
+}
+
+#[derive(Debug, Args)]
+/// Arguments for the `usage` subcommand.
+pub struct UsageArgs {
+    /// Output format
+    #[arg(long, value_name = "FORMAT", value_enum, default_value = "json")]
+    pub format: UsageOutputFormat,
 }
 
 #[derive(Debug, Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod search;
 #[path = "test-support.rs"]
 mod test_support;
 mod types;
+mod usage;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, shells};
@@ -46,7 +47,7 @@ use crate::cli::{
     ErrorOutputFormat, ExtractOutputFormat, HistorySubcommand, McpArgs, NewsFilterMode,
     NewsFilterScope, NotifyArgs, OutputFormat, QuickOutputFormat, SearchArgs, SearchOrder,
     SearchTime, SitePrefMode, SitePrefSubcommand, SkillsCommand, SkillsSubcommand, TranslateArgs,
-    WatchArgs,
+    UsageOutputFormat, WatchArgs,
 };
 use crate::error::KagiError;
 use crate::quick::{execute_quick, format_quick_markdown, format_quick_pretty};
@@ -351,6 +352,18 @@ async fn run() -> Result<(), KagiError> {
             AuthSubcommand::Check => run_auth_check(profile.as_deref()).await,
             AuthSubcommand::Set(args) => run_auth_set(args, profile.as_deref()),
         },
+        Commands::Usage(args) => {
+            let token = resolve_session_token(profile.as_deref())?;
+            let report = usage::execute_usage(&token).await?;
+            match args.format {
+                UsageOutputFormat::Json => print_json(&report),
+                UsageOutputFormat::Compact => print_compact_json(&report),
+                UsageOutputFormat::Pretty => {
+                    println!("{}", usage::format_pretty(&report));
+                    Ok(())
+                }
+            }
+        }
         Commands::Agent => {
             let content = agent::skill_content(agent::KAGI_SKILL).ok_or_else(|| {
                 KagiError::Config("embedded kagi skill is unavailable".to_string())

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,0 +1,611 @@
+//! Account billing and usage reporting.
+//!
+//! Fetches the authenticated Kagi billing settings page with session-token auth
+//! and parses the current plan, AI-cost allowance, renewal metadata, and daily
+//! calendar-month usage.
+
+use reqwest::{StatusCode, header};
+use scraper::{Html, Selector};
+use serde::Serialize;
+
+use crate::error::KagiError;
+use crate::http;
+
+const KAGI_BILLING_PATH: &str = "/settings/billing";
+const TEXT_CANDIDATE_LIMIT: usize = 512;
+const AI_COST_LABEL: &str = "total ai cost this period";
+const ACCOUNT_BALANCE_LABEL: &str = "account balance";
+const NEXT_RENEWAL_LABEL: &str = "next renewal is";
+
+/// Account billing and calendar-month usage reported by Kagi.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct UsageReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan: Option<String>,
+    pub ai_cost: AiCostUsage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_balance_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_renewal: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_period: Option<String>,
+    pub daily_usage: Vec<DailyUsage>,
+}
+
+/// AI cost consumed and included allowance, in USD.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct AiCostUsage {
+    pub used_usd: f64,
+    pub limit_usd: f64,
+}
+
+/// One row from the billing page's calendar-month usage table.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct DailyUsage {
+    pub date: String,
+    pub searches: u64,
+    pub ai_cost_usd: f64,
+}
+
+/// Fetches and parses the authenticated Kagi billing page.
+///
+/// # Errors
+///
+/// Returns authentication errors for a missing or expired session token,
+/// network errors for failed HTTP requests, and parse errors when Kagi's page
+/// no longer exposes the required AI cost values.
+pub async fn execute_usage(session_token: &str) -> Result<UsageReport, KagiError> {
+    let session_token = session_token.trim();
+    if session_token.is_empty() {
+        return Err(KagiError::Auth(
+            "missing Kagi session token (expected KAGI_SESSION_TOKEN)".to_string(),
+        ));
+    }
+
+    let response = http::client_20s()?
+        .get(http::kagi_url(KAGI_BILLING_PATH))
+        .header(header::COOKIE, format!("kagi_session={session_token}"))
+        .header(header::ACCEPT, "text/html")
+        .send()
+        .await
+        .map_err(http::map_transport_error)?;
+
+    let status = response.status();
+    let final_path = response.url().path().to_ascii_lowercase();
+    if final_path.contains("/login") || final_path.contains("/signin") {
+        return Err(KagiError::Auth(
+            "invalid or expired Kagi session token for billing usage".to_string(),
+        ));
+    }
+
+    if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+        return Err(KagiError::Auth(format!(
+            "invalid or expired Kagi session token for billing usage: HTTP {status}"
+        )));
+    }
+
+    if !status.is_success() {
+        let body = http::read_error_body(response, "billing usage").await;
+        let redacted_body = body.replace(session_token, "<redacted>");
+        let suffix = http::error_body_suffix(&redacted_body);
+        let message = if status.is_server_error() {
+            format!("Kagi billing server error: HTTP {status}{suffix}")
+        } else {
+            format!("unexpected Kagi billing response status: HTTP {status}{suffix}")
+        };
+        return Err(KagiError::Network(message));
+    }
+
+    let body = response.text().await.map_err(|error| {
+        KagiError::Network(format!(
+            "failed to read Kagi billing response body: {error}"
+        ))
+    })?;
+
+    if looks_like_logged_out_page(&body) {
+        return Err(KagiError::Auth(
+            "invalid or expired Kagi session token for billing usage".to_string(),
+        ));
+    }
+
+    parse_usage_html(&body)
+}
+
+/// Formats a usage report for human-readable terminal output.
+pub fn format_pretty(report: &UsageReport) -> String {
+    let mut lines = Vec::new();
+
+    if let Some(plan) = report.plan.as_deref() {
+        lines.push(format!("Plan: {plan}"));
+    }
+    lines.push(format!(
+        "AI cost: ${:.2} / ${:.2}",
+        report.ai_cost.used_usd, report.ai_cost.limit_usd
+    ));
+    if let Some(balance) = report.account_balance_usd {
+        lines.push(format!("Account balance: ${balance:.2}"));
+    }
+    if let Some(next_renewal) = report.next_renewal.as_deref() {
+        lines.push(format!("Next renewal: {next_renewal}"));
+    }
+    if let Some(period) = report.usage_period.as_deref() {
+        lines.push(format!("Usage period: {period}"));
+    }
+
+    if !report.daily_usage.is_empty() {
+        lines.push(String::new());
+        lines.push(format!(
+            "{:<10}  {:>10}  {:>13}",
+            "Date", "Searches", "AI cost (USD)"
+        ));
+        for row in &report.daily_usage {
+            lines.push(format!(
+                "{:<10}  {:>10}  {:>13.3}",
+                row.date, row.searches, row.ai_cost_usd
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
+/// Parses billing-page HTML into a structured usage report.
+fn parse_usage_html(html: &str) -> Result<UsageReport, KagiError> {
+    let document = Html::parse_document(html);
+    let candidates = text_candidates(&document);
+    let ai_cost = extract_ai_cost(&candidates).ok_or_else(|| {
+        KagiError::Parse(
+            "Kagi billing page did not contain the current AI cost and limit; the page layout may have changed"
+                .to_string(),
+        )
+    })?;
+
+    Ok(UsageReport {
+        plan: extract_plan(&candidates),
+        ai_cost,
+        account_balance_usd: extract_first_decimal_after_label(&candidates, ACCOUNT_BALANCE_LABEL),
+        next_renewal: extract_text_after_label(&candidates, NEXT_RENEWAL_LABEL)
+            .and_then(|text| extract_iso_date(&text)),
+        usage_period: extract_usage_period(&candidates),
+        daily_usage: parse_daily_usage(&document),
+    })
+}
+
+/// Collects short, normalized visible-text candidates from the page.
+fn text_candidates(document: &Html) -> Vec<String> {
+    let selector = Selector::parse("body *").expect("static selector should parse");
+    let mut candidates = Vec::new();
+
+    for element in document.select(&selector) {
+        if matches!(
+            element.value().name(),
+            "script" | "style" | "noscript" | "svg" | "path"
+        ) {
+            continue;
+        }
+
+        let text = normalize_space(&element.text().collect::<Vec<_>>().join(" "));
+        if text.is_empty() || text.len() > TEXT_CANDIDATE_LIMIT || candidates.contains(&text) {
+            continue;
+        }
+        candidates.push(text);
+    }
+
+    candidates.sort_by_key(String::len);
+    candidates
+}
+
+/// Extracts the current AI cost and included limit from text candidates.
+fn extract_ai_cost(candidates: &[String]) -> Option<AiCostUsage> {
+    candidates.iter().find_map(|candidate| {
+        let tail = slice_after_label(candidate, AI_COST_LABEL)?;
+        let values = decimal_values(tail);
+        if values.len() < 2 {
+            return None;
+        }
+        Some(AiCostUsage {
+            used_usd: values[0],
+            limit_usd: values[1],
+        })
+    })
+}
+
+/// Extracts the first decimal value following a case-insensitive label.
+fn extract_first_decimal_after_label(candidates: &[String], label: &str) -> Option<f64> {
+    candidates.iter().find_map(|candidate| {
+        slice_after_label(candidate, label).and_then(|tail| decimal_values(tail).into_iter().next())
+    })
+}
+
+/// Extracts non-empty text following a case-insensitive label.
+fn extract_text_after_label(candidates: &[String], label: &str) -> Option<String> {
+    candidates.iter().find_map(|candidate| {
+        let tail = slice_after_label(candidate, label)?.trim();
+        (!tail.is_empty()).then_some(tail.to_string())
+    })
+}
+
+/// Returns the portion of text after a case-insensitive ASCII label.
+fn slice_after_label<'a>(text: &'a str, label: &str) -> Option<&'a str> {
+    let lower = text.to_ascii_lowercase();
+    let offset = lower.find(label)?;
+    Some(&text[offset + label.len()..])
+}
+
+/// Extracts the plan name from a monthly or yearly price description.
+fn extract_plan(candidates: &[String]) -> Option<String> {
+    candidates.iter().find_map(|candidate| {
+        let lower = candidate.to_ascii_lowercase();
+        if !lower.contains("per month") && !lower.contains("per year") {
+            return None;
+        }
+
+        let boundary = candidate
+            .char_indices()
+            .find_map(|(index, character)| {
+                (character.is_ascii_digit() || matches!(character, '$' | '€' | '£'))
+                    .then_some(index)
+            })
+            .unwrap_or(candidate.len());
+        let mut plan = candidate[..boundary]
+            .trim_matches(|character: char| {
+                character.is_whitespace() || matches!(character, ':' | '-' | '–' | '—')
+            })
+            .to_string();
+
+        for prefix in ["Switch Plan", "Current Plan"] {
+            if let Some(stripped) = plan.strip_prefix(prefix) {
+                plan = stripped.trim().to_string();
+            }
+        }
+
+        (!plan.is_empty()).then_some(plan)
+    })
+}
+
+/// Extracts a calendar-month heading such as `December 2025`.
+fn extract_usage_period(candidates: &[String]) -> Option<String> {
+    const MONTHS: [&str; 12] = [
+        "january",
+        "february",
+        "march",
+        "april",
+        "may",
+        "june",
+        "july",
+        "august",
+        "september",
+        "october",
+        "november",
+        "december",
+    ];
+
+    candidates.iter().find_map(|candidate| {
+        let words = candidate.split_whitespace().collect::<Vec<_>>();
+        if words.len() != 2
+            || !MONTHS
+                .iter()
+                .any(|month| words[0].eq_ignore_ascii_case(month))
+            || words[1].len() != 4
+            || !words[1].chars().all(|character| character.is_ascii_digit())
+        {
+            return None;
+        }
+        Some(candidate.clone())
+    })
+}
+
+/// Parses the first table containing date, search, and AI-cost columns.
+fn parse_daily_usage(document: &Html) -> Vec<DailyUsage> {
+    let table_selector = Selector::parse("table").expect("static selector should parse");
+    let row_selector = Selector::parse("tr").expect("static selector should parse");
+    let cell_selector = Selector::parse("th, td").expect("static selector should parse");
+
+    for table in document.select(&table_selector) {
+        let rows = table
+            .select(&row_selector)
+            .map(|row| {
+                row.select(&cell_selector)
+                    .map(|cell| normalize_space(&cell.text().collect::<Vec<_>>().join(" ")))
+                    .collect::<Vec<_>>()
+            })
+            .filter(|row| !row.is_empty())
+            .collect::<Vec<_>>();
+
+        let Some((header_index, date_index, searches_index, cost_index)) =
+            rows.iter().enumerate().find_map(|(row_index, row)| {
+                let date_index = row
+                    .iter()
+                    .position(|cell| cell.to_ascii_lowercase().contains("date"))?;
+                let searches_index = row
+                    .iter()
+                    .position(|cell| cell.to_ascii_lowercase().contains("search"))?;
+                let cost_index = row.iter().position(|cell| {
+                    let lower = cell.to_ascii_lowercase();
+                    lower.contains("ai cost") || lower == "cost" || lower.contains("cost (usd)")
+                })?;
+                Some((row_index, date_index, searches_index, cost_index))
+            })
+        else {
+            continue;
+        };
+
+        let required_index = date_index.max(searches_index).max(cost_index);
+        let parsed = rows
+            .iter()
+            .skip(header_index + 1)
+            .filter_map(|row| {
+                if row.len() <= required_index {
+                    return None;
+                }
+                let date = extract_iso_date(&row[date_index])?;
+                let searches = parse_search_count(&row[searches_index])?;
+                let ai_cost_usd = decimal_values(&row[cost_index]).into_iter().next()?;
+                Some(DailyUsage {
+                    date,
+                    searches,
+                    ai_cost_usd,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        if !parsed.is_empty() {
+            return parsed;
+        }
+    }
+
+    Vec::new()
+}
+
+/// Parses a search count while ignoring locale-specific grouping separators.
+fn parse_search_count(text: &str) -> Option<u64> {
+    let digits = text
+        .chars()
+        .filter(char::is_ascii_digit)
+        .collect::<String>();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
+/// Extracts decimal values from free-form text.
+fn decimal_values(text: &str) -> Vec<f64> {
+    let mut values = Vec::new();
+    let mut token = String::new();
+
+    for character in text.chars().chain(std::iter::once(' ')) {
+        if character.is_ascii_digit()
+            || matches!(character, '.' | ',' | '\'' | '\u{00a0}' | '\u{202f}')
+        {
+            token.push(character);
+            continue;
+        }
+
+        if let Some(value) = parse_decimal_token(&token) {
+            values.push(value);
+        }
+        token.clear();
+    }
+
+    values
+}
+
+/// Parses one decimal token with comma, period, or grouped separators.
+fn parse_decimal_token(token: &str) -> Option<f64> {
+    let compact = token
+        .chars()
+        .filter(|character| character.is_ascii_digit() || matches!(character, '.' | ','))
+        .collect::<String>();
+    if compact.is_empty() || !compact.chars().any(|character| character.is_ascii_digit()) {
+        return None;
+    }
+
+    let last_separator = compact
+        .char_indices()
+        .rev()
+        .find(|(_, character)| matches!(character, '.' | ','));
+    let normalized = if let Some((separator_index, separator)) = last_separator {
+        let fractional_digits = compact[separator_index + separator.len_utf8()..]
+            .chars()
+            .filter(char::is_ascii_digit)
+            .count();
+        let has_prior_same_separator = compact[..separator_index]
+            .chars()
+            .any(|character| character == separator);
+        let has_other_separator = compact
+            .chars()
+            .any(|character| matches!(character, '.' | ',') && character != separator);
+
+        if (1..=3).contains(&fractional_digits)
+            && !(has_prior_same_separator && !has_other_separator)
+        {
+            compact
+                .char_indices()
+                .filter_map(|(index, character)| {
+                    if character.is_ascii_digit() {
+                        Some(character)
+                    } else if index == separator_index {
+                        Some('.')
+                    } else {
+                        None
+                    }
+                })
+                .collect::<String>()
+        } else {
+            compact
+                .chars()
+                .filter(char::is_ascii_digit)
+                .collect::<String>()
+        }
+    } else {
+        compact
+    };
+
+    normalized.parse().ok()
+}
+
+/// Extracts the first `YYYY-MM-DD` date from text.
+fn extract_iso_date(text: &str) -> Option<String> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 10 {
+        return None;
+    }
+
+    for start in 0..=bytes.len() - 10 {
+        let candidate = &bytes[start..start + 10];
+        if candidate[0..4].iter().all(u8::is_ascii_digit)
+            && candidate[4] == b'-'
+            && candidate[5..7].iter().all(u8::is_ascii_digit)
+            && candidate[7] == b'-'
+            && candidate[8..10].iter().all(u8::is_ascii_digit)
+        {
+            return Some(text[start..start + 10].to_string());
+        }
+    }
+
+    None
+}
+
+/// Collapses all Unicode whitespace runs to single ASCII spaces.
+fn normalize_space(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Detects common logged-out page markers returned after an auth redirect.
+fn looks_like_logged_out_page(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower.contains("<title>kagi search - a premium search engine</title>")
+        || lower.contains("welcome to kagi")
+        || (lower.contains("sign in") && lower.contains("create an account"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AiCostUsage, DailyUsage, format_pretty, parse_decimal_token, parse_usage_html};
+
+    /// Returns representative localized billing HTML for parser tests.
+    fn billing_fixture() -> &'static str {
+        r#"
+        <html>
+          <body>
+            <section class="plan">
+              <span>Ultimate</span>
+              <span>$25 (+tax) per month</span>
+            </section>
+            <section class="summary">
+              <div>
+                <span>Total AI cost this period (USD)</span>
+                <strong>$0,00/25,00</strong>
+              </div>
+              <div>
+                <span>Account balance</span>
+                <strong>$5.00</strong>
+              </div>
+            </section>
+            <p>Next renewal is <strong>2026-01-28</strong></p>
+            <div class="usage-heading">December 2025</div>
+            <table>
+              <thead>
+                <tr>
+                  <th>Date (UTC)</th>
+                  <th>Searches</th>
+                  <th>AI Cost (USD)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>2025-12-29</td><td>2</td><td>0.000</td></tr>
+                <tr><td>2025-12-28</td><td>1,234</td><td>1.125</td></tr>
+              </tbody>
+            </table>
+          </body>
+        </html>
+        "#
+    }
+
+    /// Verifies summary fields and daily rows from representative billing HTML.
+    #[test]
+    fn parses_billing_summary_and_daily_usage() {
+        let report = parse_usage_html(billing_fixture()).expect("fixture should parse");
+
+        assert_eq!(report.plan.as_deref(), Some("Ultimate"));
+        assert_eq!(
+            report.ai_cost,
+            AiCostUsage {
+                used_usd: 0.0,
+                limit_usd: 25.0,
+            }
+        );
+        assert_eq!(report.account_balance_usd, Some(5.0));
+        assert_eq!(report.next_renewal.as_deref(), Some("2026-01-28"));
+        assert_eq!(report.usage_period.as_deref(), Some("December 2025"));
+        assert_eq!(
+            report.daily_usage,
+            vec![
+                DailyUsage {
+                    date: "2025-12-29".to_string(),
+                    searches: 2,
+                    ai_cost_usd: 0.0,
+                },
+                DailyUsage {
+                    date: "2025-12-28".to_string(),
+                    searches: 1234,
+                    ai_cost_usd: 1.125,
+                },
+            ]
+        );
+    }
+
+    /// Verifies daily columns are selected by header rather than position.
+    #[test]
+    fn maps_daily_columns_by_header_name() {
+        let html = r#"
+        <html><body>
+          <div>Total AI cost this period (USD) $1.25 / $25.00</div>
+          <table>
+            <tr><th>Date</th><th>AI Tokens</th><th>AI Cost</th><th>Searches</th></tr>
+            <tr><td>2026-08-21</td><td>42,000</td><td>0,125</td><td>17</td></tr>
+          </table>
+        </body></html>
+        "#;
+
+        let report = parse_usage_html(html).expect("alternate table should parse");
+        assert_eq!(report.daily_usage.len(), 1);
+        assert_eq!(report.daily_usage[0].searches, 17);
+        assert!((report.daily_usage[0].ai_cost_usd - 0.125).abs() < f64::EPSILON);
+    }
+
+    /// Verifies decimal and grouping conventions used by localized billing pages.
+    #[test]
+    fn parses_common_decimal_conventions() {
+        assert_eq!(parse_decimal_token("0,00"), Some(0.0));
+        assert_eq!(parse_decimal_token("25.00"), Some(25.0));
+        assert_eq!(parse_decimal_token("1.234,56"), Some(1234.56));
+        assert_eq!(parse_decimal_token("1,234.56"), Some(1234.56));
+        assert_eq!(parse_decimal_token("1,234,567"), Some(1_234_567.0));
+        assert_eq!(parse_decimal_token("1.234.567"), Some(1_234_567.0));
+    }
+
+    /// Verifies missing required cost values produce a layout-change error.
+    #[test]
+    fn reports_layout_changes_when_cost_pair_is_missing() {
+        let error = parse_usage_html("<html><body>Billing Details</body></html>")
+            .expect_err("missing cost pair should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("did not contain the current AI cost and limit")
+        );
+    }
+
+    /// Verifies terminal output includes the key summary and usage fields.
+    #[test]
+    fn formats_pretty_output() {
+        let report = parse_usage_html(billing_fixture()).expect("fixture should parse");
+        let output = format_pretty(&report);
+        assert!(output.contains("Plan: Ultimate"));
+        assert!(output.contains("AI cost: $0.00 / $25.00"));
+        assert!(output.contains("2025-12-29"));
+    }
+}

--- a/tests/integration-cli.rs
+++ b/tests/integration-cli.rs
@@ -383,6 +383,47 @@ fn session_env(server: &MockServer) -> Vec<(&'static str, String)> {
 }
 
 #[test]
+fn usage_command_returns_billing_report() {
+    let server = MockServer::start();
+    let billing = server.mock(|when, then| {
+        when.method(GET)
+            .path("/settings/billing")
+            .header("cookie", "kagi_session=test-session");
+        then.status(200).header("content-type", "text/html").body(
+            r#"
+                <html><body>
+                  <div>Ultimate $25 (+tax) per month</div>
+                  <div>Total AI cost this period (USD) $2,50 / $25,00</div>
+                  <div>Account balance $5.00</div>
+                  <p>Next renewal is 2026-01-28</p>
+                  <div>August 2026</div>
+                  <table>
+                    <tr><th>Date (UTC)</th><th>Searches</th><th>AI Cost (USD)</th></tr>
+                    <tr><td>2026-08-21</td><td>7</td><td>0.125</td></tr>
+                  </table>
+                </body></html>
+                "#,
+        );
+    });
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let env = session_env(&server);
+    let output = run_kagi(
+        &["usage", "--format", "json"],
+        &env_refs(&env),
+        tempdir.path(),
+    );
+
+    assert_success(&output);
+    billing.assert_calls(1);
+    let body: Value = serde_json::from_slice(&output.stdout).expect("usage JSON should parse");
+    assert_eq!(body["plan"], "Ultimate");
+    assert_eq!(body["ai_cost"]["used_usd"], 2.5);
+    assert_eq!(body["ai_cost"]["limit_usd"], 25.0);
+    assert_eq!(body["daily_usage"][0]["searches"], 7);
+}
+
+#[test]
 fn assistant_prompt_stream_reads_query_from_stdin() {
     let server = MockServer::start();
     let current_prompt = mock_current_assistant_prompt(


### PR DESCRIPTION
Closes #163

## Summary

Adds a session-authenticated `kagi usage` command, with `kagi billing` as a visible alias, to report the current plan, AI cost used and limit, account balance, renewal date, and calendar-month usage.

## Change type

- [x] Feature
- [ ] Fix
- [x] Documentation
- [x] Tests
- [ ] Breaking change

## Implementation overview

- Fetches `/settings/billing` using the existing `kagi_session` cookie path.
- Parses localized decimal and grouping conventions for AI cost, allowance, balance, and daily usage.
- Exposes `json`, `compact`, and `pretty` output formats.
- Detects expired-session redirects and redacts the session token from HTTP error bodies.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo check --workspace --all-targets --locked`
- [x] `cargo test --workspace --all-targets --locked`
- [x] Mocked CLI integration test verifies the billing request, session cookie, and JSON response.
- [x] Parser tests cover localized decimal formats, repeated thousands separators, table-column mapping, missing required values, and pretty output.

## Docs

- Added `docs/commands/usage.mdx`.
- Updated command navigation, `llms.txt`, auth matrix, product coverage, account-config skill guidance, and changelog.

## Auth / Secrets

- Requires `KAGI_SESSION_TOKEN` or a configured session-token profile.
- Reuses existing credential resolution; no new credential storage is introduced.
- Session tokens are never printed and are redacted from response-body diagnostics.

## Release notes

Added `kagi usage` / `kagi billing` for structured and human-readable account billing and AI-usage reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `kagi usage` to view plan details, AI usage, balance, renewal date, and daily calendar-month usage.
  * Added `kagi billing` as an alias.
  * Supports JSON, compact JSON, and human-readable output formats.
  * Requires authentication with a session token.

* **Documentation**
  * Added command reference, authentication details, coverage information, and usage examples.

* **Tests**
  * Added coverage for authenticated usage retrieval and output data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->