### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.18.0]
+
 ### Added
 
 - `kagi mcp` now auto-negotiates the wire protocol per request: draft `2026-07-28` requests with `params._meta` metadata keep `server/discover` and cache hints, while requests without it — including `initialize`, `ping`, `tools/list`, and `tools/call` — are answered per the stable MCP specification.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "kagi"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kagi"
-version = "0.17.2"
+version = "0.18.0"
 edition = "2024"
 description = "Agent-native CLI for Kagi subscribers with JSON-first search output"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagi-cli",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Node wrapper that installs the native kagi CLI binary",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release preparation for v0.18.0.

- Bump crate version 0.17.2 → 0.18.0 (Cargo.toml + Cargo.lock)
- Promote `[Unreleased]` changelog entries to `## [0.18.0]` (bare heading per #167 parser alignment)
- Also bump npm wrapper (`npm/package.json`) 0.17.1 → 0.18.0: missed in the v0.17.2 release PR, and `npm/lib/install.cjs` derives the binary download tag from this version, so the published wrapper would otherwise keep installing v0.17.1 binaries

Local verification (matching release.yml): `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-targets --locked` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.18.0.
  * Updated package metadata to reflect the new release.
  * Added the 0.18.0 entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->