### PR TITLE
chore: release v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.18.1]
+
+### Fixed
+
+- `kagi usage` no longer rejects valid sessions with an authentication error and parses Kagi's current billing page layout, including the new "AI usage (USD)" cost box (#173).
+
 ## [0.18.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "kagi"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kagi"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 description = "Agent-native CLI for Kagi subscribers with JSON-first search output"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagi-cli",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Node wrapper that installs the native kagi CLI binary",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release preparation for v0.18.1 (patch: `kagi usage` fix from #173).

- Bump crate version 0.18.0 → 0.18.1 (Cargo.toml + Cargo.lock)
- Promote the `[Unreleased]` changelog entry to `## [0.18.1]` (bare heading, parser-aligned per #167)
- Bump npm wrapper (`npm/package.json`) 0.18.0 → 0.18.1 so the wrapper installs matching binaries

Local verification (matching release.yml): `cargo fmt --check`, strict clippy, locked test suite — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `kagi usage` authentication errors for valid sessions.
  * Updated billing usage parsing to support the current Kagi layout, including AI usage costs.

* **Chores**
  * Bumped the application version to 0.18.1.
  * Documented the fixes in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->